### PR TITLE
Task/380 Extra Chance

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ a full list of changes to the project, please consult the commit log.
 ## [Unreleased]
 
 ### Changed
+- Extra Chance:
+    - Has been adjusted to be more rewarding at all bonuses.
+    - Maximum bonus increased from `5x` to `10x`.
+    - The bonus now increases when the current target is in the same class
+      as the previous target. Classes are defined as Perfects and Slates.
+    - If the bonus is `4x` or higher, hitting the target will now decrease
+      it by `4x` (e.g. `4x` becomes `0x`).  If the bonus is `3x` or lower,
+      it will continue to be cleared.
 - Elder Slate armor debuff no longer improves with levels, and now remains
   at the base value of `-7`.
 

--- a/share/objects/mine.lua
+++ b/share/objects/mine.lua
@@ -483,21 +483,23 @@ do
 					.. ' current target is set.|n'
 
 					.. '-'
-					.. ' Failing to hit the target and selecting the same'
-					.. ' one in the next placement round will increase a'
-					.. ' bonus that starts at `0x`.|n'
+					.. ' There are two Extra Chance classes: Perfects and'
+					.. ' Slates.|n'
 
 					.. '-'
-					.. ' Not using Extra Chance for a placement round will'
-					.. ' cause the bonus to decrease.|n'
+					.. ' The bonus starts at `0x`, and will increase by'
+					.. ' `1x` only when the current target is in the same'
+					.. ' class as the previous target.|n'
 
 					.. '-'
-					.. ' Switching to a different target from the previous'
-					.. ' placement round does not alter the bonus.|n'
+					.. ' Not using Extra Chance for a round will cause the'
+					.. ' bonus to decrease by `1x`.|n'
 
 					.. '-'
-					.. ' At the maximum `5x` bonus, the player will only'
-					.. ' be offered gems related to their target.|n'
+					.. ' Hitting the target will cause the bonus to'
+					.. ' decrease by `4x`. If this would reduce the bonus'
+					.. ' below `0x`, then the target and bonus are'
+					.. ' cleared.|n'
 			}
 		}
 	end

--- a/share/objects/mine.lua
+++ b/share/objects/mine.lua
@@ -478,9 +478,10 @@ do
 			values = {
 				[1] = ''
 					.. '-'
-					.. ' The current target is shown on the board in white.'
-					.. ' The previous target is shown in grey when no'
-					.. ' current target is set.|n'
+					.. ' The current target is shown on the board in white,'
+					.. ' indicating that Extra Chance is active. The '
+					.. ' previous target is shown in grey when no current'
+					.. ' target is set.|n'
 
 					.. '-'
 					.. ' There are two Extra Chance classes: Perfects and'

--- a/src/gem/changelog/unreleased.j
+++ b/src/gem/changelog/unreleased.j
@@ -4,6 +4,11 @@ function Gem_Changelog___Unreleased takes nothing returns nothing
 	local string text = ""
 
 	set text = text + Color__Gold ("Changed:") + "|n"
+	set text = text + "- Extra Chance:|n"
+	set text = text + "    - Has been adjusted to be more rewarding at all bonuses.|n"
+	set text = text + "    - Maximum bonus increased from `5x` to `10x`.|n"
+	set text = text + "    - The bonus now increases when the current target is in the same class as the previous target. Classes are defined as Perfects and Slates.|n"
+	set text = text + "    - If the bonus is `4x` or higher, hitting the target will now decrease it by `4x` (e.g. `4x` becomes `0x`).  If the bonus is `3x` or lower, it will continue to be cleared.|n"
 	set text = text + "- Elder Slate armor debuff no longer improves with levels, and now remains at the base value of `-7`.|n"
 	set text = text + "|n"
 

--- a/src/gem/extra-chance.j
+++ b/src/gem/extra-chance.j
@@ -70,6 +70,7 @@ function Gem_Extra_Chance__Set takes player whom, integer target returns boolean
 	local boolean is_slate
 
 	local integer whom_id
+	local integer previous
 	local integer bonus
 	local integer cost
 
@@ -92,20 +93,21 @@ function Gem_Extra_Chance__Set takes player whom, integer target returns boolean
 	endif
 
 	set whom_id = GetPlayerId (whom)
+	set previous = Gem_Extra_Chance___Previous_Target [whom_id]
 
 	// Already active and same target.
 	if Gem_Extra_Chance___Current_Target [whom_id] == target then
 		return true
 
 	// No target during previous round or the bonus reset.
-	elseif Gem_Extra_Chance___Previous_Target [whom_id] == 0 then
+	elseif previous == 0 then
 		set bonus = 0
 
-	// Same target as previous round.
-	elseif Gem_Extra_Chance___Previous_Target [whom_id] == target then
+	// Same class as previous round.
+	elseif (is_gem and Gem_Gems__Is_Gem (previous)) or (is_slate and Gem_Slate__Is_Slate (previous)) then
 		set bonus = IMinBJ (Gem_Extra_Chance___Previous_Bonus [whom_id] + 1, Gem_Extra_Chance___MAXIMUM_BONUS)
 
-	// Different target than previous round.
+	// Different class than previous round.
 	else
 		set bonus = Gem_Extra_Chance___Previous_Bonus [whom_id]
 	endif

--- a/src/gem/extra-chance.j
+++ b/src/gem/extra-chance.j
@@ -4,41 +4,39 @@ globals
 	constant integer Gem_Extra_Chance__TYPE_COST = 175
 	constant integer Gem_Extra_Chance__SLATE_COST = 125
 
+	constant integer Gem_Extra_Chance___ROLLS = 5
+	integer array Gem_Extra_Chance___Rolls
+	boolean array Gem_Extra_Chance___Rolls_Generated
+
+	constant integer Gem_Extra_Chance___TOTAL_WEIGHT = 80
+	constant integer Gem_Extra_Chance___MAXIMUM_BONUS = 10
+	constant integer Gem_Extra_Chance___THRESHOLD_BONUS = 5
+
+	constant real Gem_Extra_Chance___Slate_Initial = 18.75
+	constant real Gem_Extra_Chance___Slate_Per = (Gem_Extra_Chance___TOTAL_WEIGHT - Gem_Extra_Chance___Slate_Initial) / (Gem_Extra_Chance___THRESHOLD_BONUS)
+
+	constant real Gem_Extra_Chance___Slate_Bias = 2.5
+	real array Gem_Extra_Chance___Slate_Biases
+
+	constant real Gem_Extra_Chance___Type_Initial = 25.00
+	constant real Gem_Extra_Chance___Type_Per = (Gem_Extra_Chance___TOTAL_WEIGHT - Gem_Extra_Chance___Type_Initial) / (Gem_Extra_Chance___THRESHOLD_BONUS)
+
+	constant real Gem_Extra_Chance___Type_Bias = 2.0
+	real array Gem_Extra_Chance___Type_Biases
+
+	constant real Gem_Extra_Chance___Slate_Two = 0.67
+	constant real Gem_Extra_Chance___Slate_Three = 0.75
+
+	constant real Gem_Extra_Chance___Type_Perfect = 0.190
+	constant real Gem_Extra_Chance___Type_Flawless = 0.238
+	constant real Gem_Extra_Chance___Type_Normal = 0.238
+	constant real Gem_Extra_Chance___Type_Flawed = 0.238
+	constant real Gem_Extra_Chance___Type_Chipped = 0.096
+
 	integer array Gem_Extra_Chance___Current_Target
 	integer array Gem_Extra_Chance___Current_Bonus
 	integer array Gem_Extra_Chance___Previous_Target
 	integer array Gem_Extra_Chance___Previous_Bonus
-
-	real array Gem_Extra_Chance___Type_Weights
-	real array Gem_Extra_Chance___Slate_Two_Weights
-	real array Gem_Extra_Chance___Slate_Three_Weights
-
-	// Target: Perfect gem.
-	constant real Gem_Extra_Chance___Type_Perfect = 5.25
-	constant real Gem_Extra_Chance___Type_Flawless = 7.5
-	constant real Gem_Extra_Chance___Type_Normal = 7.5
-	constant real Gem_Extra_Chance___Type_Flawed = 7.5
-	constant real Gem_Extra_Chance___Type_Chipped = 2.5
-
-	// Target: Two-piece slate.
-	constant real Gem_Extra_Chance___Slate_Two_A0 = 12
-	constant real Gem_Extra_Chance___Slate_Two_A1 = 6
-	constant real Gem_Extra_Chance___Slate_Two_A2 = 6
-
-	constant real Gem_Extra_Chance___Slate_Two_B0 = 6
-	constant real Gem_Extra_Chance___Slate_Two_B1 = 3
-	constant real Gem_Extra_Chance___Slate_Two_B2 = 3
-	constant real Gem_Extra_Chance___Slate_Two_B3 = 3
-
-	// Target: Three-piece slate.
-	constant real Gem_Extra_Chance___Slate_Three_A0 = 6
-	constant real Gem_Extra_Chance___Slate_Three_A1 = 3
-	constant real Gem_Extra_Chance___Slate_Three_A2 = 3
-
-	constant real Gem_Extra_Chance___Slate_Three_B0 = 12
-	constant real Gem_Extra_Chance___Slate_Three_B1 = 6
-	constant real Gem_Extra_Chance___Slate_Three_B2 = 6
-	constant real Gem_Extra_Chance___Slate_Three_B3 = 6
 
 	constant integer ERROR__NOT_GEM_PLAYER = ID ()
 	constant integer ERROR__PLACEMENT_HAS_STARTED = ID ()
@@ -73,16 +71,7 @@ function Gem_Extra_Chance__Set takes player whom, integer target returns boolean
 
 	local integer whom_id
 	local integer bonus
-	local real weight
 	local integer cost
-
-	local integer array gems
-	local real array weights
-	local integer index
-
-	local integer type_id
-	local integer A
-	local integer B
 
 	if not Gem_Player__Is_Player (whom) then
 		call Error (ERROR__NOT_GEM_PLAYER, null)
@@ -114,7 +103,7 @@ function Gem_Extra_Chance__Set takes player whom, integer target returns boolean
 
 	// Same target as previous round.
 	elseif Gem_Extra_Chance___Previous_Target [whom_id] == target then
-		set bonus = IMinBJ (Gem_Extra_Chance___Previous_Bonus [whom_id] + 1, 5)
+		set bonus = IMinBJ (Gem_Extra_Chance___Previous_Bonus [whom_id] + 1, Gem_Extra_Chance___MAXIMUM_BONUS)
 
 	// Different target than previous round.
 	else
@@ -133,83 +122,13 @@ function Gem_Extra_Chance__Set takes player whom, integer target returns boolean
 	endif
 
 	if Gem_Gems__Is_Gem (target) then
-		set type_id = Gem_Gems__Get_ID_Type (target)
-
-		set gems [0] = Gem_Gems__Get_Unit_Type (type_id, Gem_Quality__PERFECT)
-		set gems [1] = Gem_Gems__Get_Unit_Type (type_id, Gem_Quality__FLAWLESS)
-		set gems [2] = Gem_Gems__Get_Unit_Type (type_id, Gem_Quality__NORMAL)
-		set gems [3] = Gem_Gems__Get_Unit_Type (type_id, Gem_Quality__FLAWED)
-		set gems [4] = Gem_Gems__Get_Unit_Type (type_id, Gem_Quality__CHIPPED)
-
-		set weight = Gem_Extra_Chance___Type_Weights [bonus]
 		set cost = Gem_Extra_Chance__TYPE_COST
-
-		set weights [0] = weight * Gem_Extra_Chance___Type_Perfect
-		set weights [1] = weight * Gem_Extra_Chance___Type_Flawless
-		set weights [2] = weight * Gem_Extra_Chance___Type_Normal
-		set weights [3] = weight * Gem_Extra_Chance___Type_Flawed
-		set weights [4] = weight * Gem_Extra_Chance___Type_Chipped
 	else
 		set cost = Gem_Extra_Chance__SLATE_COST
-
-		if Gem_Slate__Size (target) == 2 then
-			set weight = Gem_Extra_Chance___Slate_Two_Weights [bonus]
-
-			set weights [0] = weight * Gem_Extra_Chance___Slate_Two_A0
-			set weights [1] = weight * Gem_Extra_Chance___Slate_Two_A1
-			set weights [2] = weight * Gem_Extra_Chance___Slate_Two_A2
-			set weights [3] = weight * Gem_Extra_Chance___Slate_Two_B0
-			set weights [4] = weight * Gem_Extra_Chance___Slate_Two_B1
-			set weights [5] = weight * Gem_Extra_Chance___Slate_Two_B2
-			set weights [6] = weight * Gem_Extra_Chance___Slate_Two_B3
-
-			set A = target
-			set B = Gem_Selection_Slate___Get_Other_Part (target)
-		else
-			set weight = Gem_Extra_Chance___Slate_Three_Weights [bonus]
-
-			set weights [0] = weight * Gem_Extra_Chance___Slate_Three_A0
-			set weights [1] = weight * Gem_Extra_Chance___Slate_Three_A1
-			set weights [2] = weight * Gem_Extra_Chance___Slate_Three_A2
-			set weights [3] = weight * Gem_Extra_Chance___Slate_Three_B0
-			set weights [4] = weight * Gem_Extra_Chance___Slate_Three_B1
-			set weights [5] = weight * Gem_Extra_Chance___Slate_Three_B2
-			set weights [6] = weight * Gem_Extra_Chance___Slate_Three_B3
-
-			set A = Gem_Selection_Slate___Get_Other_Part (target)
-			set B = target
-		endif
-
-		set gems [0] = Gem_Slate__Get_Normal (A)
-		set gems [1] = Gem_Slate__Get_Flawed_A (A)
-		set gems [2] = Gem_Slate__Get_Flawed_B (A)
-		set gems [3] = Gem_Slate__Get_Normal (B)
-		set gems [4] = Gem_Slate__Get_Flawed_A (B)
-		set gems [5] = Gem_Slate__Get_Flawed_B (B)
-		set gems [6] = Gem_Slate__Get_Flawed_C (B)
 	endif
 
 	// Charge the cost for the new current target.
 	call AdjustPlayerStateSimpleBJ (whom, PLAYER_STATE_RESOURCE_GOLD, -cost)
-
-	// A weight less than zero implies that we need to clear the entire
-	// placement table first.  Essentially, this makes it impossible to get
-	// anything but gems related to the target.
-	if weight < 0 then
-		call Gem_Chance__Clear (whom)
-
-	// We only need to reset the placement table if we are changing targets in
-	// the current round.
-	elseif Gem_Extra_Chance___Current_Target [whom_id] != target then
-		call Gem_Chance__Reset (whom)
-	endif
-
-	set index = 0
-	loop
-		call Gem_Placement__Set_Weight (whom, gems [index], RAbsBJ (weights [index]))
-		set index = index + 1
-		exitwhen gems [index] == 0
-	endloop
 
 	set Gem_Extra_Chance___Current_Target [whom_id] = target
 	set Gem_Extra_Chance___Current_Bonus [whom_id] = bonus
@@ -225,8 +144,6 @@ function Gem_Extra_Chance__Clear takes player whom returns nothing
 	if not Gem_Extra_Chance__Is_Active (whom) then
 		return
 	endif
-
-	call Gem_Chance__Reset (whom)
 
 	set whom_id = GetPlayerId (whom)
 	set target = Gem_Extra_Chance___Current_Target [whom_id]
@@ -269,6 +186,267 @@ function Gem_Extra_Chance___Extra_Chanced takes unit placed returns nothing
 	call SetTextTagColor (tag, 255, 255, 255, 255)
 endfunction
 
+function Gem_Extra_Chance___Get_Flawed takes real roll, integer slate returns integer
+	local integer size = Gem_Slate__Size (slate)
+
+	set roll = roll * size
+
+	if roll <= 1.0 then
+		return Gem_Slate__Get_Flawed_A (slate)
+	elseif roll <= 2.0 then
+		return Gem_Slate__Get_Flawed_B (slate)
+	endif
+
+	return Gem_Slate__Get_Flawed_C (slate)
+endfunction
+
+function Gem_Extra_Chance___Get_Quality takes real roll returns integer
+	local real weight = Gem_Extra_Chance___Type_Chipped
+
+	if roll < weight then
+		return Gem_Quality__CHIPPED
+	endif
+
+	set roll = roll - weight
+	set weight = Gem_Extra_Chance___Type_Flawed
+
+	if roll < weight then
+		return Gem_Quality__FLAWED
+	endif
+
+	set roll = roll - weight
+	set weight = Gem_Extra_Chance___Type_Normal
+
+	if roll < weight then
+		return Gem_Quality__NORMAL
+	endif
+
+	set roll = roll - weight
+	set weight = Gem_Extra_Chance___Type_Flawless
+
+	if roll < weight then
+		return Gem_Quality__FLAWLESS
+	endif
+
+	return Gem_Quality__PERFECT
+endfunction
+
+function Gem_Extra_Chance___Get_Slate takes real roll, integer target returns integer
+	local integer size = Gem_Slate__Size (target)
+	local real chance
+
+	if size == 2 then
+		set chance = Gem_Extra_Chance___Slate_Two
+	else
+		set chance = Gem_Extra_Chance___Slate_Three
+	endif
+
+	if roll < chance then
+		return target
+	else
+		// TODO: This is a private function.  It should not be accessed.
+		// Although, it would be wise to move this to Gem Slates.
+		return Gem_Selection_Slate___Get_Other_Part (target)
+	endif
+endfunction
+
+function Gem_Extra_Chance___Rolls_Index takes integer whom_id , integer index returns integer
+	return whom_id * Gem_Extra_Chance___ROLLS + index
+endfunction
+
+function Gem_Extra_Chance___Set_Roll takes integer whom_id, integer index, integer value returns nothing
+	set Gem_Extra_Chance___Rolls [Gem_Extra_Chance___Rolls_Index (whom_id, index)] = value
+endfunction
+
+function Gem_Extra_Chance___Get_Roll takes integer whom_id, integer index returns integer
+	return Gem_Extra_Chance___Rolls [Gem_Extra_Chance___Rolls_Index (whom_id, index)]
+endfunction
+
+function Gem_Extra_Chance___Clear_Rolls takes integer whom_id returns nothing
+	local integer index
+
+	set index = Gem_Extra_Chance___ROLLS
+	loop
+		set index = index - 1
+		exitwhen index < 0
+
+		call Gem_Extra_Chance___Set_Roll (whom_id, index, 0)
+	endloop
+
+	set Gem_Extra_Chance___Rolls_Generated [whom_id] = false
+endfunction
+
+function Gem_Extra_Chance___Shuffle_Rolls takes integer whom_id returns nothing
+	local integer i
+	local integer j
+	local integer A
+	local integer B
+
+	set i = Gem_Extra_Chance___ROLLS
+	loop
+		set i = i - 1
+		exitwhen i == 1
+
+		set j = GetRandomInt (0, i)
+		set A = Gem_Extra_Chance___Get_Roll (whom_id, i)
+		set B = Gem_Extra_Chance___Get_Roll (whom_id, j)
+
+		call Gem_Extra_Chance___Set_Roll (whom_id, i, B)
+		call Gem_Extra_Chance___Set_Roll (whom_id, j, A)
+	endloop
+endfunction
+
+function Gem_Extra_Chance___Perfect_Rolls takes integer whom_id returns nothing
+	local integer target = Gem_Extra_Chance___Current_Target [whom_id]
+	local integer bonus = Gem_Extra_Chance___Current_Bonus [whom_id]
+
+	local real bias = Gem_Extra_Chance___Type_Biases [bonus]
+	local real weight = Gem_Extra_Chance___Type_Initial
+	local real per = Gem_Extra_Chance___Type_Per
+
+	local integer index
+	local real roll
+	local integer gem
+
+	local integer type_id = Gem_Gems__Get_ID_Type (target)
+	local integer quality_id
+
+	if bonus >= Gem_Extra_Chance___THRESHOLD_BONUS then
+		set weight = Gem_Extra_Chance___TOTAL_WEIGHT
+	else
+		set weight = weight + per * bonus
+	endif
+
+	set weight = weight / Gem_Extra_Chance___TOTAL_WEIGHT
+	set index = 0
+	loop
+		set roll = GetRandomReal (0.0, 1.0)
+		set quality_id = ID__NULL
+
+		if roll <= bias then
+			if roll < Gem_Extra_Chance___Type_Chipped then
+				set quality_id = Gem_Quality__CHIPPED
+			else
+				set quality_id = Gem_Quality__PERFECT
+			endif
+		elseif roll <= weight then
+			set roll = roll / weight
+			set quality_id = Gem_Extra_Chance___Get_Quality (roll)
+		endif
+
+		set gem = Gem_Gems__Get_Unit_Type (type_id, quality_id)
+		call Gem_Extra_Chance___Set_Roll (whom_id, index, gem)
+
+		set index = index + 1
+		exitwhen index == Gem_Extra_Chance___ROLLS
+	endloop
+endfunction
+
+function Gem_Extra_Chance___Slate_Rolls takes integer whom_id returns nothing
+	local integer target = Gem_Extra_Chance___Current_Target [whom_id]
+	local integer bonus = Gem_Extra_Chance___Current_Bonus [whom_id]
+
+	local real bias = Gem_Extra_Chance___Slate_Biases [bonus]
+	local real weight = Gem_Extra_Chance___Slate_Initial
+	local real per = Gem_Extra_Chance___Slate_Per
+
+	local integer index
+	local real array rolls
+	local real roll
+	local integer gem
+
+	local boolean is_bias = false
+	local integer slate = 0
+
+	set index = 0
+	loop
+		set rolls [index] = GetRandomReal (0.0, 1.0)
+		set is_bias = is_bias or rolls [index] <= bias
+
+		set index = index + 1
+		exitwhen index == Gem_Extra_Chance___ROLLS
+	endloop
+
+	if is_bias or bonus >= Gem_Extra_Chance___THRESHOLD_BONUS then
+		set weight = Gem_Extra_Chance___TOTAL_WEIGHT
+	else
+		set weight = weight + per * bonus
+	endif
+
+	set weight = weight / Gem_Extra_Chance___TOTAL_WEIGHT
+	set index = 0
+	loop
+		set roll = rolls [index]
+		set gem = 0
+
+		if roll <= weight then
+			set roll = roll / weight
+
+			if slate == 0 then
+				if is_bias and index < 4 then
+					set roll = I2R (index / 2)
+				endif
+
+				set slate = Gem_Extra_Chance___Get_Slate (roll, target)
+				set gem = Gem_Slate__Get_Normal (slate)
+			else
+				set gem = Gem_Extra_Chance___Get_Flawed (roll, slate)
+				set slate = 0
+			endif
+		endif
+
+		call Gem_Extra_Chance___Set_Roll (whom_id, index, gem)
+
+		set index = index + 1
+		exitwhen index == Gem_Extra_Chance___ROLLS
+	endloop
+
+	call Gem_Extra_Chance___Shuffle_Rolls (whom_id)
+endfunction
+
+function Gem_Extra_Chance___On_Start takes nothing returns nothing
+	local player whom = Gem_Placement__The_Player ()
+	local integer whom_id = GetPlayerId (whom)
+
+	call Gem_Extra_Chance___Clear_Rolls (whom_id)
+endfunction
+
+function Gem_Extra_Chance___On_Pre_Placement takes nothing returns nothing
+	local player whom = Gem_Placement__The_Player ()
+	local integer whom_id
+
+	local integer target
+	local integer index
+	local integer gem
+
+	if not Gem_Extra_Chance__Is_Active (whom) then
+		return
+	endif
+
+	set whom_id = GetPlayerId (whom)
+	set target = Gem_Extra_Chance___Current_Target [whom_id]
+
+	if not Gem_Extra_Chance___Rolls_Generated [whom_id] then
+		if Gem_Gems__Is_Gem (target) then
+			call Gem_Extra_Chance___Perfect_Rolls (whom_id)
+		else
+			call Gem_Extra_Chance___Slate_Rolls (whom_id)
+		endif
+
+		set Gem_Extra_Chance___Rolls_Generated [whom_id] = true
+	endif
+
+	set index = Gem_Placement__Placed (whom)
+	set gem = Gem_Extra_Chance___Get_Roll (whom_id, index)
+
+	// Having a gem to roll for implies that the player will get this exact
+	// gem.  An empty roll implies business as usual.
+	if gem > 0 then
+		call Gem_Chance__Clear (whom)
+		call Gem_Placement__Set_Weight (whom, gem, 1.0)
+	endif
+endfunction
+
 function Gem_Extra_Chance___On_Placement takes nothing returns boolean
 	local player whom = Gem_Placement__The_Player ()
 	local integer whom_id = GetPlayerId (whom)
@@ -284,18 +462,21 @@ function Gem_Extra_Chance___On_Placement takes nothing returns boolean
 			call Gem_Extra_Chance___Extra_Chanced (placed)
 		endif
 
+		call Gem_Chance__Reset (whom)
+
 	// No active Extra Chance and the first gem has been placed?  It is too late
 	// to enable, so decay the previous bonus and adjust accordingly.
 	elseif Gem_Placement__Placed (whom) == 1 then
 		set Gem_Extra_Chance___Current_Target [whom_id] = 0
 		set Gem_Extra_Chance___Current_Bonus [whom_id] = 0
 
-		if Gem_Extra_Chance___Previous_Bonus [whom_id] == 0 then
-			set Gem_Extra_Chance___Previous_Target [whom_id] = 0
-		endif
+		set bonus = Gem_Extra_Chance___Previous_Bonus [whom_id]
 
-		set bonus = IMaxBJ (Gem_Extra_Chance___Previous_Bonus [whom_id] - 1, 0)
-		set Gem_Extra_Chance___Previous_Bonus [whom_id] = bonus
+		if bonus == 0 then
+			set Gem_Extra_Chance___Previous_Target [whom_id] = 0
+		else
+			set Gem_Extra_Chance___Previous_Bonus [whom_id] = bonus - 1
+		endif
 	endif
 
 	return false
@@ -307,8 +488,6 @@ function Gem_Extra_Chance___On_Finish takes nothing returns boolean
 	local integer bonus
 	local integer target
 	local boolean has_target
-	local boolean is_slate
-	local integer index
 
 	if not Gem_Extra_Chance__Is_Active (whom) then
 		return false
@@ -324,7 +503,6 @@ function Gem_Extra_Chance___On_Finish takes nothing returns boolean
 		set has_target = Gem_Selection_Slate__Has (whom, target)
 	endif
 
-	call Gem_Chance__Reset (whom)
 	set Gem_Extra_Chance___Current_Target [whom_id] = 0
 	set Gem_Extra_Chance___Current_Bonus [whom_id] = 0
 
@@ -340,74 +518,23 @@ function Gem_Extra_Chance___On_Finish takes nothing returns boolean
 	return false
 endfunction
 
-function Gem_Extra_Chance___Weight takes real total, integer bonus returns real
-	return 3500 / (total - 80) / (bonus - 5) - 3500 / total / (bonus - 5) - 700 / total
-endfunction
-
-function Gem_Extra_Chance___Initialize_Type_Weights takes nothing returns nothing
-	local real total = 0
-
-	set total = total + Gem_Extra_Chance___Type_Perfect
-	set total = total + Gem_Extra_Chance___Type_Flawless
-	set total = total + Gem_Extra_Chance___Type_Normal
-	set total = total + Gem_Extra_Chance___Type_Flawed
-	set total = total + Gem_Extra_Chance___Type_Chipped
-
-	set Gem_Extra_Chance___Type_Weights [0] = Gem_Extra_Chance___Weight (total, 0)
-	set Gem_Extra_Chance___Type_Weights [1] = Gem_Extra_Chance___Weight (total, 1)
-	set Gem_Extra_Chance___Type_Weights [2] = Gem_Extra_Chance___Weight (total, 2)
-	set Gem_Extra_Chance___Type_Weights [3] = Gem_Extra_Chance___Weight (total, 3)
-	set Gem_Extra_Chance___Type_Weights [4] = Gem_Extra_Chance___Weight (total, 4)
-	set Gem_Extra_Chance___Type_Weights [5] = -1 // Must zero the table.
-endfunction
-
-function Gem_Extra_Chance___Initialize_Slate_Two_Weights takes nothing returns nothing
-	local real total = 0
-
-	set total = total + Gem_Extra_Chance___Slate_Two_A0
-	set total = total + Gem_Extra_Chance___Slate_Two_A1
-	set total = total + Gem_Extra_Chance___Slate_Two_A2
-	set total = total + Gem_Extra_Chance___Slate_Two_B0
-	set total = total + Gem_Extra_Chance___Slate_Two_B1
-	set total = total + Gem_Extra_Chance___Slate_Two_B2
-	set total = total + Gem_Extra_Chance___Slate_Two_B3
-
-	set Gem_Extra_Chance___Slate_Two_Weights [0] = Gem_Extra_Chance___Weight (total, 0)
-	set Gem_Extra_Chance___Slate_Two_Weights [1] = Gem_Extra_Chance___Weight (total, 1)
-	set Gem_Extra_Chance___Slate_Two_Weights [2] = Gem_Extra_Chance___Weight (total, 2)
-	set Gem_Extra_Chance___Slate_Two_Weights [3] = Gem_Extra_Chance___Weight (total, 3)
-	set Gem_Extra_Chance___Slate_Two_Weights [4] = Gem_Extra_Chance___Weight (total, 4)
-	set Gem_Extra_Chance___Slate_Two_Weights [5] = -1 // Must zero the table.
-endfunction
-
-function Gem_Extra_Chance___Initialize_Slate_Three_Weights takes nothing returns nothing
-	local real total = 0
-
-	set total = total + Gem_Extra_Chance___Slate_Three_A0
-	set total = total + Gem_Extra_Chance___Slate_Three_A1
-	set total = total + Gem_Extra_Chance___Slate_Three_A2
-	set total = total + Gem_Extra_Chance___Slate_Three_B0
-	set total = total + Gem_Extra_Chance___Slate_Three_B1
-	set total = total + Gem_Extra_Chance___Slate_Three_B2
-	set total = total + Gem_Extra_Chance___Slate_Three_B3
-
-	set Gem_Extra_Chance___Slate_Three_Weights [0] = Gem_Extra_Chance___Weight (total, 0)
-	set Gem_Extra_Chance___Slate_Three_Weights [1] = Gem_Extra_Chance___Weight (total, 1)
-	set Gem_Extra_Chance___Slate_Three_Weights [2] = Gem_Extra_Chance___Weight (total, 2)
-	set Gem_Extra_Chance___Slate_Three_Weights [3] = Gem_Extra_Chance___Weight (total, 3)
-	set Gem_Extra_Chance___Slate_Three_Weights [4] = Gem_Extra_Chance___Weight (total, 4)
-	set Gem_Extra_Chance___Slate_Three_Weights [5] = -1 // Must zero the table.
-endfunction
-
-
 function Gem_Extra_Chance__Initialize takes nothing returns boolean
+	local integer bonus
+
 	call Game__On_Start (Condition (function Gem_Extra_Chance_Menu__Initialize))
+	call Gem_Placement__On_Start (Condition (function Gem_Extra_Chance___On_Start))
+	call Gem_Placement__On_Pre_Placement (Condition (function Gem_Extra_Chance___On_Pre_Placement))
 	call Gem_Placement__On_Placement (Condition (function Gem_Extra_Chance___On_Placement))
 	call Gem_Placement__On_Finish (Condition (function Gem_Extra_Chance___On_Finish))
 
-	call Gem_Extra_Chance___Initialize_Type_Weights ()
-	call Gem_Extra_Chance___Initialize_Slate_Two_Weights ()
-	call Gem_Extra_Chance___Initialize_Slate_Three_Weights ()
+	set bonus = 0
+	loop
+		set Gem_Extra_Chance___Slate_Biases [bonus] = Pow (Gem_Extra_Chance___Slate_Bias, bonus - Gem_Extra_Chance___MAXIMUM_BONUS)
+		set Gem_Extra_Chance___Type_Biases [bonus] = Pow (Gem_Extra_Chance___Type_Bias, bonus - Gem_Extra_Chance___MAXIMUM_BONUS)
+
+		set bonus = bonus + 1
+		exitwhen bonus > Gem_Extra_Chance___MAXIMUM_BONUS
+	endloop
 
 	return false
 endfunction

--- a/src/gem/extra-chance.j
+++ b/src/gem/extra-chance.j
@@ -464,8 +464,8 @@ function Gem_Extra_Chance___On_Placement takes nothing returns boolean
 
 		call Gem_Chance__Reset (whom)
 
-	// No active Extra Chance and the first gem has been placed?  It is too late
-	// to enable, so decay the previous bonus and adjust accordingly.
+	// No active Extra Chance and the first gem has been placed?  It is too
+	// late to enable, so decay the previous bonus and adjust accordingly.
 	elseif Gem_Placement__Placed (whom) == 1 then
 		set Gem_Extra_Chance___Current_Target [whom_id] = 0
 		set Gem_Extra_Chance___Current_Bonus [whom_id] = 0

--- a/src/gem/extra-chance.j
+++ b/src/gem/extra-chance.j
@@ -509,8 +509,13 @@ function Gem_Extra_Chance___On_Finish takes nothing returns boolean
 	set Gem_Extra_Chance___Current_Bonus [whom_id] = 0
 
 	if has_target then
-		set Gem_Extra_Chance___Previous_Target [whom_id] = 0
-		set Gem_Extra_Chance___Previous_Bonus [whom_id] = 0
+		if bonus > 3 then
+			set Gem_Extra_Chance___Previous_Target [whom_id] = target
+			set Gem_Extra_Chance___Previous_Bonus [whom_id] = bonus - 4
+		else
+			set Gem_Extra_Chance___Previous_Target [whom_id] = 0
+			set Gem_Extra_Chance___Previous_Bonus [whom_id] = 0
+		endif
 		set udg_CountExtrachance [whom_id + 1] = udg_CountExtrachance [whom_id + 1] + 1
 	else
 		set Gem_Extra_Chance___Previous_Target [whom_id] = target

--- a/src/gem/placement.j
+++ b/src/gem/placement.j
@@ -54,6 +54,7 @@ globals
 	// FIFO ordering is simple to implement given that is how triggers
 	// execute/evaluate.
 	constant trigger Gem_Placement___ON_START = CreateTrigger ()
+	constant trigger Gem_Placement___ON_PRE_PLACEMENT = CreateTrigger()
 	constant trigger Gem_Placement___ON_PLACEMENT = CreateTrigger ()
 	constant trigger Gem_Placement___ON_FINISH = CreateTrigger ()
 endglobals
@@ -82,6 +83,12 @@ endfunction
 // functions are executed in registration order (FIFO).
 function Gem_Placement__On_Start takes boolexpr callback returns nothing
 	call TriggerAddCondition (Gem_Placement___ON_START, callback)
+endfunction
+
+// This occurs after a placement event has started, but before the random
+// gem has been finalized.  It is possible to adjust weights here.
+function Gem_Placement__On_Pre_Placement takes boolexpr callback returns nothing
+	call TriggerAddCondition (Gem_Placement___ON_PRE_PLACEMENT, callback)
 endfunction
 
 // Registers the provided `callback` to fire after a placement structure is
@@ -290,14 +297,16 @@ function Gem_Placement___Placement takes nothing returns boolean
 		return false
 	endif
 
-	set Gem_Placement___Placed [index__player] = Gem_Placement___Placed [index__player] + 1
-
 	call ShowUnit (old, false)
 
 	set Gem_Placement___The_Player = the_player
+	call TriggerEvaluate (Gem_Placement___ON_PRE_PLACEMENT)
+
 	set Gem_Placement___The_Unit = PlaceRandomUnit (Gem_Placement___POOL [index__player], the_player, GetUnitX (old), GetUnitY (old), GetUnitFacing (old))
 
 	call RemoveUnit (old)
+
+	set Gem_Placement___Placed [index__player] = Gem_Placement___Placed [index__player] + 1
 
 	call TriggerEvaluate (Gem_Placement___ON_PLACEMENT)
 


### PR DESCRIPTION
# Extra Chance
Attempt at implementing #380. Specifically deals with #411 so far.

## Testing Version
- [Gem TD Plus 1.6-xc-9_g9e3ded7.w3x.zip](https://github.com/nvs/gem/files/3066567/Gem.TD.Plus.1.6-xc-9_g9e3ded7.w3x.zip)

## To-Do
- [x] Update Changelog.
- [x] Update tooltips.
- [x] Mention that Extra Chance is only active if a current target is set.

### General Rework
- [x] Add a bias towards one-hit combinations when using Extra Chance for Slates.
- [x] Adjust bias for Perfects to be exponential, like that for Slates.
- [x] Let the bonus grow up to `10x`. No one should honestly reach that point. But, let's support it. For bonuses above `5x`, the bias is all that improves.

### Specific Issues
- [x] Allow the bonus to grow within the same class of target (i.e. Perfects or Slates).
- [x] Decrease the bonus by `4x` upon hitting the target. So, for `3x` and below this means the existing behavior does not change. For higher bonuses, it decreases. For example, `Opal (4x)` would become `Opal (0x)` after hitting the target. If a player opts, they could invest and turn it into `Opal (1x)` (or `Diamond (1x)` with the in-class bonus growth).

## Things to Consider
- [x] ~~Aligning the gold cost. This would allow the bonus to always grow if gold is spent.~~ Not happening. Extra Chance for Slates will always be less rewarding. Having the cost be the same simply does not work.