### PR TITLE
Feature/416 Building Rework

### DIFF
--- a/lib/gem/hotkey.lua
+++ b/lib/gem/hotkey.lua
@@ -1,0 +1,4 @@
+return function (key)
+	assert (#key == 1)
+	return string.format ('|cffffcc00%s|r', key)
+end

--- a/share/constants/interface/gem.lua
+++ b/share/constants/interface/gem.lua
@@ -124,10 +124,6 @@ CustomSkin.InfoPanelIconDamageSiege =
 CustomSkin.InfoPanelIconDamageSiegeNeutral =
 	'ReplaceableTextures\\CommandButtons\\BTNAntiMagicShell.blp'
 
--- Icon - Command - Basic Structure (Undead):
-CustomSkin.CommandBasicStructUndead =
-	'ReplaceableTextures\\CommandButtons\\BTNAdvStruct.blp'
-
 -- Icon - Defense Type Divine (Bryvx):
 CustomSkin.InfoPanelIconArmorDivine =
 	'ReplaceableTextures\\CommandButtons\\BTNMedivh.blp'

--- a/share/objects/builder.lua
+++ b/share/objects/builder.lua
@@ -1,0 +1,17 @@
+local map = ...
+local objects = map.objects
+
+-- # Miner
+do
+	local unit = objects.u000
+
+	-- ## Stats
+
+	-- Race:
+	--
+	-- The type of construction depends on the unit's race.
+	unit.urac = {
+		type = 'string',
+		value = 'orc'
+	}
+end

--- a/src/gem/placement.j
+++ b/src/gem/placement.j
@@ -359,7 +359,6 @@ endfunction
 function Gem_Placement___Move_Builder takes player whom, real X, real Y returns nothing
 	local integer whom_id = GetPlayerId (whom)
 	local region marked = Gem_Placement___Marked [whom_id]
-	local rect area = udg_GA [whom_id + 1]
 	local unit builder = Gem_Player__Get_Miner (whom)
 	local real x
 	local real y

--- a/src/gem/placement.j
+++ b/src/gem/placement.j
@@ -34,6 +34,7 @@ globals
 	// The lumber cost for the placement structure.
 	constant integer Gem_Placement___PLACEMENT_UNIT_COST = 1
 
+	unit array Gem_Placement___Progress
 	unit array Gem_Placement___Constructing
 
 	// Each player has their own unique pool, which contains up to date unit
@@ -255,10 +256,23 @@ function Gem_Placement__Clear_Weight takes player the_player, integer unit_type 
 	call Gem_Placement__Set_Weight (the_player, unit_type, 0.00)
 endfunction
 
+function Gem_Placement___Progress takes nothing returns boolean
+	local integer runner = Run__Scheduled ()
+	local unit which
+
+	set which = Gem_Placement___Progress [runner]
+	set Gem_Placement___Progress [runner] = null
+
+	call UnitSetConstructionProgress (which, 50)
+
+	return true
+endfunction
+
 function Gem_Placement___Start takes nothing returns nothing
 	local unit which = GetTriggerUnit ()
 	local player whom
 	local integer whom_id
+	local integer runner
 
 	if GetUnitTypeId (which) != Gem_Placement___PLACEMENT_UNIT_ID then
 		return
@@ -268,6 +282,9 @@ function Gem_Placement___Start takes nothing returns nothing
 	set whom_id = GetPlayerId (whom)
 
 	set Gem_Placement___Constructing [whom_id] = which
+
+	set runner = Run__After (0.0, function Gem_Placement___Progress)
+	set Gem_Placement___Progress [runner] = which
 endfunction
 
 function Gem_Placement___Escape takes nothing returns nothing


### PR DESCRIPTION
# Building Rework
Attempt at implementing #416.

## Testing Version
- [Gem TD Plus 1.6-br-8_gb5bc534.w3x.zip](https://github.com/nvs/gem/files/3144954/Gem.TD.Plus.1.6-br-8_gb5bc534.w3x.zip)

This replaces the existing build style with Orc building. `Esc` can be used to cancel building while having the builder selected (which it will be if he has just gone inside to build). Probably want to utilize `Shift` to queue up build orders.

This has the potential to be slower than the older style, depending on the player (i.e. if you use fast building it may feel slower). I've noticed, however, that this also increases my ability to recognize and respond to one-hits. Overall, races should be more competitive as building speed (and probably ping) won't factor in as heavily.

## To-Do
- [x] Shift the builder's position after finishing the last gem, as his presence makes it difficult to select the placed gems. Need to shift him away from all placed gems.
- [x] Try out Human building. *Not a fan.*
    - Detect any order that would stop construction and cancel the building.
- [ ] Mention in Changelog.

## Notes
- It seems impossible to change the icon of the build menu without exporting/importing it. Previously, with Undead style of building it used the icon for the Undead build menu. The icon has changed, and is now that of the Orc menu.

## Options
1. ~~Replacing rocks using the built in haunt style.~~ This is not viable, as discussed in https://github.com/nvs/gem/pull/418#issuecomment-479283112. Request made to improve the usability of this action [made here at Hive](https://www.hiveworkshop.com/threads/feedback-request-features-for-jass-and-the-world-editor.308099/page-9#post-3337780).
2. Orc style building. This is a possibility if there is a desire to move away from fast building. It strictly prevents it. The `Esc` key can be detected to make cancelling construction easier. I foresee a heavier use of `Shift` to queue up build orders.
\
This is potentially slower than the older style. I've noticed that this also increases my ability to recognize and respond to one-hits. Times will be slower, however, for players used to fast building. But, overall, races should be more competitive as building won't factor in as heavily.
\
Seems to be much easier to use (probably due to the slower pace) in high ping situations. I've made far fewer mistakes in such situations. This may help foster competition on Battle.net where people could be from anywhere around the world, as they may be less inclined to avoid certain hosts.
3. Spread out the hurt of building over a longer period. For example, allow players to plan their construction during the round itself. They could build placeholders on open ground that do not path block. And placeholders on top of rocks that would maintain path blocking. Upon clearing a round or the use of a specific ability, all these placeholders would be replaced with random gems.
\
In a situation with an explicit roll ability, the placement phase would not really exist. All that would exist is the planning phase (which would begin the moment a round starts until that roll ability it used), and the selection phase (which entails picking from one of the random gems).
4. Something with Tiny Farm. This is basically Undead style of construction. It has the distinct advantage of using a real to define construction duration, thus allowing subsecond resolution. It could be used in conjunction with default building. A couple downsides do come to mind, so this is probably not too useful:
    - The lack of a building shadow when creating a queue of builder orders.
    - A built in cast delay that cannot be resolved, that makes fast building frustrating and error prone.
5. Adding a replace ability onto rocks. This is probably the simplest option. However, it introduces a new mechanic. Needing to use both mechanics in the same build phase may feel awkward. The mechanics are related, but are not very similar. Place a random gem with the builder and select a rock and hit a replace ability? Not very intuitive. Then again, people already select rocks to remove them every round.

## Thoughts
I would prefer to have the ability to replace rocks via haunt (Option 1).  All in all, it keeps things simple. The responsibility of placing gems, either by building or replacing, would remain with the builder. Putting a replace ability onto rocks (as in Option 5) splits the responsibility. Yes, that may seem an obvious choice to some players. And, it may be the eventual course taken. But I'm not a fan.

Now, I do like Option 3. But it is a more drastic change. It remains to be seen whether the addition of such complexity is warranted, or whether it would feel good in practice. Option 4 is not really a choice. And Option 2 makes a good simple change; albeit, people may fret over change. Particularly, the speed involved. The benefits outweigh the cost, however (see #416).

So, if Blizzard comes through with the request related to Option 1, that will be introduced. Regardless, I feel that Option 2 alone is the best course right now. And Option 1 can always be added alongside it at a later date.