### PR TITLE
Task/253 Ancient Slate Rework

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,9 @@ a full list of changes to the project, please consult the commit log.
 - Elder Slate armor debuff no longer improves with levels, and now remains
   at the base value of `-7`.
 - Spawn points have been shifted closer to the first checkpoints.
+- Ancient Slate:
+    - Armor reduction base value is now `-4`.
+    - Each additional Ancient Slate adds `-4` to the armor reduction.
 
 ### Fixed
 - Air pathing is now more consistent across all players.

--- a/share/objects/bonus-armor.lua
+++ b/share/objects/bonus-armor.lua
@@ -1,0 +1,62 @@
+local map = ...
+local objects = map.objects
+
+local list = {
+	GBAN = -4096,
+	GBA0 = 1,
+	GBA1 = 2,
+	GBA2 = 4,
+	GBA3 = 8,
+	GBA4 = 16,
+	GBA5 = 32,
+	GBA6 = 64,
+	GBA7 = 128,
+	GBA8 = 256,
+	GBA9 = 512,
+	GBAA = 1024,
+	GBAB = 2048,
+}
+
+-- # Bonus Armor Ability
+for id, armor in pairs (list) do
+	local ability = {
+		type = 'ability',
+		base = 'AId1'
+	}
+
+	objects [id] = ability
+
+	-- ## Data
+	do
+		ability.Idef = {
+			data = 1,
+			type = 'integer',
+			values = {
+				[1] = armor
+			}
+		}
+	end
+
+	-- ## Stats
+	do
+		ability.aite = {
+			type = 'integer',
+			value = 0
+		}
+	end
+
+	-- ## Text
+	do
+		-- Editor Suffix
+		ability.ansf = {
+			type = 'string',
+			value = '(' .. armor .. ')'
+		}
+
+		-- Name
+		ability.anam = {
+			type = 'string',
+			value = 'Bonus Armor'
+		}
+	end
+end

--- a/share/objects/slate/ancient.lua
+++ b/share/objects/slate/ancient.lua
@@ -1,0 +1,30 @@
+local map = ...
+local objects = map.objects
+
+-- # Armor Reduction Ability
+do
+	local ability = objects.A02I
+
+	-- ## Data
+	do
+		-- Armor Bonus
+		ability.Had1.values = {
+			[1] = 0
+		}
+	end
+
+	-- ## Stats
+	do
+		-- Area of Effect
+		ability.aare = nil
+	end
+end
+
+-- # Armor Reduction Buff
+do
+	local buff = objects.B008
+
+	buff.ftip.value = 'Ancient Slate'
+	buff.fube.value = 'This unit\'s armor has been reduced'
+		.. ' by an Ancient Slate.'
+end

--- a/src/gem/changelog/unreleased.j
+++ b/src/gem/changelog/unreleased.j
@@ -11,6 +11,9 @@ function Gem_Changelog___Unreleased_Part_1 takes nothing returns nothing
 	set text = text + "    - If the bonus is `4x` or higher, hitting the target will now decrease it by `4x` (e.g. `4x` becomes `0x`).  If the bonus is `3x` or lower, it will continue to be cleared.|n"
 	set text = text + "- Elder Slate armor debuff no longer improves with levels, and now remains at the base value of `-7`.|n"
 	set text = text + "- Spawn points have been shifted closer to the first checkpoints.|n"
+	set text = text + "- Ancient Slate:|n"
+	set text = text + "    - Armor reduction base value is now `-4`.|n"
+	set text = text + "    - Each additional Ancient Slate adds `-4` to the armor reduction.|n"
 	set text = text + "|n"
 
 	call Gem_Changelog__Setup (title, text, date)

--- a/src/gem/slate/ancient.j
+++ b/src/gem/slate/ancient.j
@@ -5,6 +5,7 @@ globals
 	unit Gem_Slate___Ancient_Unit = null
 
 	integer Gem_Slate___ID_ANCIENT_UNIT_INDEX
+	integer array Gem_Slate_Ancient___Before
 endglobals
 
 function Gem_Slate___Ancient_Taunt takes nothing returns boolean
@@ -27,11 +28,14 @@ endfunction
 function Gem_Slate___Ancient_Remove_Debuff takes nothing returns nothing
 	local integer index
 	local unit victim
+	local integer armor
 
 	set index = Handle__Load (GetExpiredTimer (), Gem_Slate___ID_ANCIENT_UNIT_INDEX)
 
 	if index > 0 then
 		set victim = Unit_Indexer__Unit_By_Index (index)
+		set armor = Gem_Slate_Ancient___Before [index]
+		call Unit_Bonus_Armor__Set (victim, armor)
 		call UnitRemoveAbility (victim, 'A02I')
 		call UnitRemoveAbility (victim, 'B008')
 	endif
@@ -40,7 +44,9 @@ endfunction
 function Gem_Slate___Ancient takes nothing returns boolean
 	local unit attacker
 	local unit victim
+	local integer index
 	local player owner
+	local integer armor
 	local texttag tag
 	local integer damage
 	local timer the_timer
@@ -53,10 +59,14 @@ function Gem_Slate___Ancient takes nothing returns boolean
 	if GetUnitTypeId (attacker) == 'n003' and not Unit_Stun__Is_Stunned (victim) then
 		set owner = GetOwningPlayer (attacker)
 
+		set index = Unit_Indexer__Unit_Index (victim)
+		set armor = Unit_Bonus_Armor__Get (victim)
+		set Gem_Slate_Ancient___Before [index] = armor
+		call Unit_Bonus_Armor__Set (victim, armor - 12)
 		call UnitAddAbility (victim, 'A02I')
 
 		set the_timer = CreateTimer ()
-		call Handle__Save (the_timer, Gem_Slate___ID_ANCIENT_UNIT_INDEX, Unit_Indexer__Unit_Index (victim))
+		call Handle__Save (the_timer, Gem_Slate___ID_ANCIENT_UNIT_INDEX, index)
 		call TimerStart (the_timer, 2.50, false, function Gem_Slate___Ancient_Remove_Debuff)
 
 		set Gem_Slate___Ancient_Unit = victim

--- a/src/gem/slate/ancient.j
+++ b/src/gem/slate/ancient.j
@@ -4,8 +4,10 @@ globals
 	group Gem_Slate___Ancient_Group = CreateGroup ()
 	unit Gem_Slate___Ancient_Unit = null
 
-	integer Gem_Slate___ID_ANCIENT_UNIT_INDEX
+	integer array Gem_Slate_Ancient___Victim
 	integer array Gem_Slate_Ancient___Before
+	integer array Gem_Slate_Ancient___Count
+	group array Gem_Slate_Ancient___Group
 endglobals
 
 function Gem_Slate___Ancient_Taunt takes nothing returns boolean
@@ -25,20 +27,23 @@ function Gem_Slate___Ancient_Taunt takes nothing returns boolean
 	return false
 endfunction
 
-function Gem_Slate___Ancient_Remove_Debuff takes nothing returns nothing
-	local integer index
+function Gem_Slate___Ancient_Remove_Debuff takes nothing returns boolean
+	local integer runner = Run__Scheduled ()
+	local integer index = Gem_Slate_Ancient___Victim [runner]
 	local unit victim
 	local integer armor
 
-	set index = Handle__Load (GetExpiredTimer (), Gem_Slate___ID_ANCIENT_UNIT_INDEX)
-
-	if index > 0 then
-		set victim = Unit_Indexer__Unit_By_Index (index)
-		set armor = Gem_Slate_Ancient___Before [index]
-		call Unit_Bonus_Armor__Set (victim, armor)
-		call UnitRemoveAbility (victim, 'A02I')
-		call UnitRemoveAbility (victim, 'B008')
+	if index == 0 then
+		return true
 	endif
+
+	set victim = Unit_Indexer__Unit_By_Index (index)
+	set armor = Gem_Slate_Ancient___Before [index]
+	call Unit_Bonus_Armor__Set (victim, armor)
+	call UnitRemoveAbility (victim, 'A02I')
+	call UnitRemoveAbility (victim, 'B008')
+
+	return true
 endfunction
 
 function Gem_Slate___Ancient takes nothing returns boolean
@@ -46,10 +51,12 @@ function Gem_Slate___Ancient takes nothing returns boolean
 	local unit victim
 	local integer index
 	local player owner
+	local integer owner_id
 	local integer armor
+	local integer debuff
 	local texttag tag
 	local integer damage
-	local timer the_timer
+	local integer runner
 	local real x
 	local real y
 
@@ -58,16 +65,17 @@ function Gem_Slate___Ancient takes nothing returns boolean
 
 	if GetUnitTypeId (attacker) == 'n003' and not Unit_Stun__Is_Stunned (victim) then
 		set owner = GetOwningPlayer (attacker)
+		set owner_id = GetPlayerId (owner)
 
 		set index = Unit_Indexer__Unit_Index (victim)
 		set armor = Unit_Bonus_Armor__Get (victim)
+		set debuff = Gem_Slate_Ancient___Count [owner_id] * 4
 		set Gem_Slate_Ancient___Before [index] = armor
-		call Unit_Bonus_Armor__Set (victim, armor - 12)
+		call Unit_Bonus_Armor__Set (victim, armor - debuff)
 		call UnitAddAbility (victim, 'A02I')
 
-		set the_timer = CreateTimer ()
-		call Handle__Save (the_timer, Gem_Slate___ID_ANCIENT_UNIT_INDEX, index)
-		call TimerStart (the_timer, 2.50, false, function Gem_Slate___Ancient_Remove_Debuff)
+		set runner = Run__After (2.50, function Gem_Slate___Ancient_Remove_Debuff)
+		set Gem_Slate_Ancient___Victim [runner] = index
 
 		set Gem_Slate___Ancient_Unit = victim
 		call GroupEnumUnitsInRange (Gem_Slate___Ancient_Group, GetUnitX (victim), GetUnitY (victim), 600.00, Filter (function Gem_Slate___Ancient_Taunt))
@@ -79,7 +87,7 @@ function Gem_Slate___Ancient takes nothing returns boolean
 		call DestroyEffect (AddSpecialEffectTarget ("Abilities\\Spells\\Other\\Charm\\CharmTarget.mdl", victim, "chest"))
 		call DestroyEffect (AddSpecialEffect ("Abilities\\Spells\\Undead\\ReplenishHealth\\ReplenishHealthCasterOverhead.mdl", x, y))
 
-		set damage = Unit_User_Data__Get (attacker) * GetRandomInt (5, 120) + udg_RLevel [GetPlayerId (owner) + 1] * 50
+		set damage = Unit_User_Data__Get (attacker) * GetRandomInt (5, 120) + udg_RLevel [owner_id + 1] * 50
 		call UnitDamageTarget (attacker, victim, damage, true, true, ATTACK_TYPE_MELEE, DAMAGE_TYPE_NORMAL, WEAPON_TYPE_WHOKNOWS)
 
 		set tag = CreateTextTag ()
@@ -103,13 +111,72 @@ function Gem_Slate___Ancient takes nothing returns boolean
 	return false
 endfunction
 
-function Gem_Slate___Initialize_Ancient takes nothing returns nothing
-	local trigger the_trigger
+function Gem_Slate_Ancient___Enter takes nothing returns nothing
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+	local player owner
+	local integer owner_id
+	local integer count
 
-	set Gem_Slate___ID_ANCIENT_UNIT_INDEX = ID ()
+	if id == Gem_Slate__ANCIENT then
+		set owner = GetOwningPlayer (which)
+		set owner_id = GetPlayerId (owner)
+		set count = Gem_Slate_Ancient___Count [owner_id] + 1
+
+		if Gem_Slate_Ancient___Group [owner_id] == null then
+			set Gem_Slate_Ancient___Group [owner_id] = CreateGroup ()
+		endif
+
+		call GroupAddUnit (Gem_Slate_Ancient___Group [owner_id], which)
+		set Gem_Slate_Ancient___Count [owner_id] = count
+	endif
+endfunction
+
+function Gem_Slate_Ancient___Leave takes nothing returns nothing
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	local player owner
+	local integer owner_id
+	local integer count
+
+	local string label
+	local string message
+
+	if id == Gem_Slate__ANCIENT then
+		set owner = GetOwningPlayer (which)
+		set owner_id = GetPlayerId (owner)
+		set count = Gem_Slate_Ancient___Count [owner_id] - 1
+
+		if count < 0 then
+			set count = 0
+
+			set label = "Gem_Slate_Ancient___Leave"
+			set message = "Bad Ancient Slate count for "
+			set message = message + "Player (" + I2S (owner_id) + ")"
+
+			call Log__Error (label, message)
+		endif
+
+		call GroupRemoveUnit (Gem_Slate_Ancient___Group [owner_id], which)
+		set Gem_Slate_Ancient___Count [owner_id] = count
+	endif
+endfunction
+
+function Gem_Slate___Initialize_Ancient takes nothing returns nothing
+	local boolexpr enter
+	local boolexpr leave
+	local trigger the_trigger
 
 	set the_trigger = CreateTrigger ()
 
 	call TriggerRegisterPlayerUnitEvent (the_trigger, Gem__PLAYER_CREEPS, EVENT_PLAYER_UNIT_ATTACKED, null)
 	call TriggerAddCondition (the_trigger, Condition (function Gem_Slate___Ancient))
+
+	set enter = Condition (function Gem_Slate_Ancient___Enter)
+	call Unit_Event__On_Enter (enter)
+
+	set leave = Condition (function Gem_Slate_Ancient___Leave)
+	call Unit_Event__On_Death (leave)
+	call Unit_Event__On_Leave (leave)
 endfunction

--- a/src/main.j
+++ b/src/main.j
@@ -166,6 +166,7 @@ function main takes nothing returns nothing
 	call TriggerAddCondition (initialize, Condition (function Unit_State__Initialize))
 	call TriggerAddCondition (initialize, Condition (function Unit_Indexer__Initialize))
 	call TriggerAddCondition (initialize, Condition (function Dummy_Caster__Initialize))
+	call TriggerAddCondition (initialize, Condition (function Unit_Bonus_Armor__Initialize))
 	call TriggerAddCondition (initialize, Condition (function Unit_User_Data__Initialize))
 	call TriggerAddCondition (initialize, Condition (function Unit_Stun__Initialize))
 	call TriggerAddCondition (initialize, Condition (function Unit_Disarm__Initialize))

--- a/src/unit/bonus/armor.j
+++ b/src/unit/bonus/armor.j
@@ -1,0 +1,121 @@
+globals
+	constant integer Unit_Bonus_Armor___NEGATIVE = 'GBAN'
+	integer array Unit_Bonus_Armor___POSITIVE
+
+	constant integer Unit_Bonus_Armor___MAXIMUM = 4095
+	constant integer Unit_Bonus_Armor___MINIMUM = -4096
+	constant integer Unit_Bonus_Armor___POWERS = 11
+endglobals
+
+function Unit_Bonus_Armor__Set takes unit which, integer value returns nothing
+	local integer index = Unit_Indexer__Unit_Index (which)
+	local integer power
+
+	if index == 0 then
+		return
+	endif
+
+	if value > Unit_Bonus_Armor___MAXIMUM then
+		return
+	endif
+
+	if value < Unit_Bonus_Armor___MINIMUM then
+		return
+	endif
+
+	if value < 0 then
+		set value = value + Unit_Bonus_Armor___MAXIMUM + 1
+
+		call UnitAddAbility (which, Unit_Bonus_Armor___NEGATIVE)
+		call UnitMakeAbilityPermanent (which, true, Unit_Bonus_Armor___NEGATIVE)
+	else
+		call UnitRemoveAbility (which, Unit_Bonus_Armor___NEGATIVE)
+	endif
+
+	set power = Unit_Bonus_Armor___POWERS
+	loop
+		if value >= Unit_State___Powers [power] then
+			call UnitAddAbility (which, Unit_Bonus_Armor___POSITIVE [power])
+			call UnitMakeAbilityPermanent (which, true, Unit_Bonus_Armor___POSITIVE [power])
+
+			set value = value - Unit_State___Powers [power]
+		else
+			call UnitRemoveAbility (which, Unit_Bonus_Armor___POSITIVE [power])
+		endif
+
+		set power = power - 1
+		exitwhen power < 0
+	endloop
+endfunction
+
+function Unit_Bonus_Armor__Get takes unit which returns integer
+	local integer index = Unit_Indexer__Unit_Index (which)
+	local integer power
+	local integer value = 0
+
+	if index == 0 then
+		return value
+	endif
+
+	if GetUnitAbilityLevel (which, Unit_Bonus_Armor___NEGATIVE) > 0 then
+		set value = Unit_Bonus_Armor___MINIMUM
+	endif
+
+	set power = Unit_Bonus_Armor___POWERS
+	loop
+		if GetUnitAbilityLevel (which, Unit_Bonus_Armor___POSITIVE [power]) > 0 then
+			set value = value + Unit_State___Powers [power]
+		endif
+
+		set power = power - 1
+		exitwhen power < 0
+	endloop
+
+	return value
+endfunction
+
+function Unit_Bonus_Armor__Clear takes unit which returns nothing
+	local integer index = Unit_Indexer__Unit_Index (which)
+	local integer power
+
+	if index == 0 then
+		return
+	endif
+
+	call UnitRemoveAbility (which, Unit_Bonus_Armor___NEGATIVE)
+
+	set power = 0
+	loop
+		call UnitRemoveAbility (which, Unit_Bonus_Armor___POSITIVE [power])
+
+		set power = power + 1
+		exitwhen power > Unit_Bonus_Armor___POWERS
+	endloop
+endfunction
+
+function Unit_Bonus_Armor__Initialize takes nothing returns nothing
+	local integer power
+
+	set Unit_Bonus_Armor___POSITIVE [0] = 'GBA0'
+	set Unit_Bonus_Armor___POSITIVE [1] = 'GBA1'
+	set Unit_Bonus_Armor___POSITIVE [2] = 'GBA2'
+	set Unit_Bonus_Armor___POSITIVE [3] = 'GBA3'
+	set Unit_Bonus_Armor___POSITIVE [4] = 'GBA4'
+	set Unit_Bonus_Armor___POSITIVE [5] = 'GBA5'
+	set Unit_Bonus_Armor___POSITIVE [6] = 'GBA6'
+	set Unit_Bonus_Armor___POSITIVE [7] = 'GBA7'
+	set Unit_Bonus_Armor___POSITIVE [8] = 'GBA8'
+	set Unit_Bonus_Armor___POSITIVE [9] = 'GBA9'
+	set Unit_Bonus_Armor___POSITIVE [10] = 'GBAA'
+	set Unit_Bonus_Armor___POSITIVE [11] = 'GBAB'
+
+	set power = Unit_Bonus_Armor___POWERS
+	loop
+		call Preload__Ability (Unit_Bonus_Armor___POSITIVE [power])
+
+		set power = power - 1
+		exitwhen power < 0
+	endloop
+
+	call Preload__Ability (Unit_Bonus_Armor___NEGATIVE)
+endfunction


### PR DESCRIPTION
# Ancient Slate Rework
Attempt at implementing #253, as well as balancing Ancient Slates in general. See also #39.

## To-Do
- [x] Make the armor reduction applied dependent on the number of Ancients. This value can begin at `-4` for one Ancient, and increase by `-4` for each additional. There does not need to be a maximum value. If a player wanted to invest heavily into Ancients, nothing is stopping them.
- [x] ~~Adjust the duration of stun to be dependent on the number of Ancients. Basically, make it possible for a single Ancient to achieve stunlock; albeit, this will not be common. As more Ancients are added, the minimum duration for a stun is increased, thus making it more and more likely that stunlock can be achieved. However, there will always be some variability. True stunlock, in the existing sense, will become a thing of the past.~~ Not implementing this part yet.