### PR TITLE
Bug/55 Immolation Rework

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,10 @@ a full list of changes to the project, please consult the commit log.
 
 ### Fixed
 - Air pathing is now more consistent across all players.
+- Sources of AoE spell damage (i.e. Immolation) have been fixed:
+    - Multiple sources will now stack.
+    - Kill bonuses now apply to this type of damage, up to `100%` bonus.
+- Viper Slate's AoE spell damage was double what was intended.
 
 ### Removed
 - Bonus gold that was awarded for reaching certain levels first has been

--- a/share/objects/slate/viper.lua
+++ b/share/objects/slate/viper.lua
@@ -1,0 +1,118 @@
+local map = ...
+local objects = map.objects
+
+local ids = {
+	immolation = 'A075'
+}
+
+-- # Viper Slate Immolation
+do
+	local ability = {
+		type = 'ability',
+		base = 'ACev'
+	}
+	objects [ids.immolation] = ability
+
+	-- ## Art
+	do
+		-- Button Position - Normal (X)
+		ability.abpx = {
+			type = 'integer',
+			value = 2
+		}
+
+		-- Button Position - Normal (Y)
+		ability.abpy = {
+			type = 'integer',
+			value = 1
+		}
+
+		-- Icon - Normal
+		ability.aart = {
+			type = 'string',
+			value = 'ReplaceableTextures\\PassiveButtons\\PASBTNStatUp.blp'
+		}
+	end
+
+	-- ## Data
+	do
+		-- Chance to Evade
+		ability.Eev1 = {
+			data = 1,
+			type = 'unreal',
+			values = {
+				[1] = 0
+			}
+		}
+	end
+
+	-- ## Stats
+	do
+		-- Area of Effect
+		ability.aare = {
+			type = 'unreal',
+			values = {
+				[1] = 400
+			}
+		}
+
+		-- Cooldown
+		ability.acdn = {
+			type = 'unreal',
+			values = {}
+		}
+
+		for level = 1, 11 do
+			ability.acdn.values [level] = 50 * (1 + 0.1 * (level - 1))
+		end
+
+		-- Levels
+		ability.alev = {
+			type = 'integer',
+			value = 11
+		}
+
+		-- Race
+		ability.arac = {
+			type = 'string',
+			value = 'human'
+		}
+	end
+
+	-- ## Text
+	do
+		-- Editor Suffix
+		ability.ansf = {
+			type = 'string',
+			value = '(Viper Slate)'
+		}
+
+		-- Name
+		ability.anam = {
+			type = 'string',
+			value = 'Abilities II'
+		}
+
+		-- Tooltip - Normal
+		ability.atp1 = {
+			type = 'string',
+			values = {
+				[1] = '|cff33ff33Viper Slate Abilities 2|r'
+			}
+		}
+
+		-- Tooltip - Normal - Extended
+		ability.aub1 = {
+			type = 'string',
+			values = {}
+		}
+
+		local text = 'Enemies within <%s,Area1> range will receive'
+			.. ' <%s,Cool%d> spell damage per second.'
+
+		for level = 1, 11 do
+			ability.aub1.values [level] = string.format (
+				text, ids.immolation, ids.immolation, level)
+		end
+	end
+end

--- a/share/objects/specials/blood-stone/01-blood-stone.lua
+++ b/share/objects/specials/blood-stone/01-blood-stone.lua
@@ -1,0 +1,123 @@
+local map = ...
+local objects = map.objects
+
+local ids = {
+	immolation = 'A00Q'
+}
+
+-- # Blood Stone Immolation
+do
+	local ability = {
+		type = 'ability',
+		base = 'ACev'
+	}
+	objects [ids.immolation] = ability
+
+	-- ## Art
+	do
+		-- Button Position - Normal (X)
+		ability.abpx = {
+			type = 'integer',
+			value = 3
+		}
+
+		-- Button Position - Normal (Y)
+		ability.abpy = {
+			type = 'integer',
+			value = 1
+		}
+
+		-- Icon - Normal
+		ability.aart = {
+			type = 'string',
+			value = 'ReplaceableTextures\\PassiveButtons\\PASBTNStatUp.blp'
+		}
+	end
+
+	-- ## Data
+	do
+		-- Chance to Evade
+		ability.Eev1 = {
+			data = 1,
+			type = 'unreal',
+			values = {
+				[1] = 0
+			}
+		}
+	end
+
+	-- ## Stats
+	do
+		-- Area of Effect
+		ability.aare = {
+			type = 'unreal',
+			values = {
+				[1] = 500
+			}
+		}
+
+		-- Cooldown
+		ability.acdn = {
+			type = 'unreal',
+			values = {}
+		}
+
+		for level = 1, 11 do
+			ability.acdn.values [level] = 60 * (1 + 0.1 * (level - 1))
+		end
+
+		-- Levels
+		ability.alev = {
+			type = 'integer',
+			value = 11
+		}
+
+		-- Race
+		ability.arac = {
+			type = 'string',
+			value = 'human'
+		}
+	end
+
+	-- ## Text
+	do
+		-- Editor Suffix
+		ability.ansf = {
+			type = 'string',
+			value = '(Blood Stone)'
+		}
+
+		-- Name
+		ability.anam = {
+			type = 'string',
+			value = 'Abilities'
+		}
+
+		-- Tooltip - Normal
+		ability.atp1 = {
+			type = 'string',
+			values = {
+				[1] = '|cff33ff33Blood Stone Abilities|r'
+			}
+		}
+
+		-- Tooltip - Normal - Extended
+		ability.aub1 = {
+			type = 'string',
+			values = {}
+		}
+
+		local text = ''
+			.. '-'
+			.. ' Attacks deal splash damage.|n'
+
+			.. '-'
+			.. ' Enemies within <%s,Area1> range will receive'
+			.. ' <%s,Cool%d> spell damage per second.'
+
+		for level = 1, 11 do
+			ability.aub1.values [level] = string.format (
+				text, ids.immolation, ids.immolation, level)
+		end
+	end
+end

--- a/share/objects/specials/red-crystal/03-rose-quartz-crystal.lua
+++ b/share/objects/specials/red-crystal/03-rose-quartz-crystal.lua
@@ -1,0 +1,118 @@
+local map = ...
+local objects = map.objects
+
+local ids = {
+	immolation = 'A01H'
+}
+
+-- # Red Quartz Crystal Immolation
+do
+	local ability = {
+		type = 'ability',
+		base = 'ACev'
+	}
+	objects [ids.immolation] = ability
+
+	-- ## Art
+	do
+		-- Button Position - Normal (X)
+		ability.abpx = {
+			type = 'integer',
+			value = 3
+		}
+
+		-- Button Position - Normal (Y)
+		ability.abpy = {
+			type = 'integer',
+			value = 1
+		}
+
+		-- Icon - Normal
+		ability.aart = {
+			type = 'string',
+			value = 'ReplaceableTextures\\PassiveButtons\\PASBTNStatUp.blp'
+		}
+	end
+
+	-- ## Data
+	do
+		-- Chance to Evade
+		ability.Eev1 = {
+			data = 1,
+			type = 'unreal',
+			values = {
+				[1] = 0
+			}
+		}
+	end
+
+	-- ## Stats
+	do
+		-- Area of Effect
+		ability.aare = {
+			type = 'unreal',
+			values = {
+				[1] = 1500
+			}
+		}
+
+		-- Cooldown
+		ability.acdn = {
+			type = 'unreal',
+			values = {}
+		}
+
+		for level = 1, 11 do
+			ability.acdn.values [level] = 50 * (1 + 0.1 * (level - 1))
+		end
+
+		-- Levels
+		ability.alev = {
+			type = 'integer',
+			value = 11
+		}
+
+		-- Race
+		ability.arac = {
+			type = 'string',
+			value = 'human'
+		}
+	end
+
+	-- ## Text
+	do
+		-- Editor Suffix
+		ability.ansf = {
+			type = 'string',
+			value = '(Rose Quartz Crystal)'
+		}
+
+		-- Name
+		ability.anam = {
+			type = 'string',
+			value = 'Abilities II'
+		}
+
+		-- Tooltip - Normal
+		ability.atp1 = {
+			type = 'string',
+			values = {
+				[1] = '|cff33ff33Rose Quartz Crystal Abilities|r'
+			}
+		}
+
+		-- Tooltip - Normal - Extended
+		ability.aub1 = {
+			type = 'string',
+			values = {}
+		}
+
+		local text = 'Enemies within <%s,Area1> range will receive'
+			.. ' <%s,Cool%d> spell damage per second.'
+
+		for level = 1, 11 do
+			ability.aub1.values [level] = string.format (
+				text, ids.immolation, ids.immolation, level)
+		end
+	end
+end

--- a/share/objects/specials/star-ruby/01-star-ruby.lua
+++ b/share/objects/specials/star-ruby/01-star-ruby.lua
@@ -1,8 +1,118 @@
 local map = ...
 local objects = map.objects
-local globals = map.globals
 
-local id = require ('lib.gem.id')
+local ids = {
+	immolation = 'A00H'
+}
 
--- # Star Ruby
-local unit = objects [id (globals.Gem_Special__STAR_RUBY_1)]
+-- # Star Ruby Immolation
+do
+	local ability = {
+		type = 'ability',
+		base = 'ACev'
+	}
+	objects [ids.immolation] = ability
+
+	-- ## Art
+	do
+		-- Button Position - Normal (X)
+		ability.abpx = {
+			type = 'integer',
+			value = 3
+		}
+
+		-- Button Position - Normal (Y)
+		ability.abpy = {
+			type = 'integer',
+			value = 1
+		}
+
+		-- Icon - Normal
+		ability.aart = {
+			type = 'string',
+			value = 'ReplaceableTextures\\PassiveButtons\\PASBTNStatUp.blp'
+		}
+	end
+
+	-- ## Data
+	do
+		-- Chance to Evade
+		ability.Eev1 = {
+			data = 1,
+			type = 'unreal',
+			values = {
+				[1] = 0
+			}
+		}
+	end
+
+	-- ## Stats
+	do
+		-- Area of Effect
+		ability.aare = {
+			type = 'unreal',
+			values = {
+				[1] = 265
+			}
+		}
+
+		-- Cooldown
+		ability.acdn = {
+			type = 'unreal',
+			values = {}
+		}
+
+		for level = 1, 11 do
+			ability.acdn.values [level] = 40 * (1 + 0.1 * (level - 1))
+		end
+
+		-- Levels
+		ability.alev = {
+			type = 'integer',
+			value = 11
+		}
+
+		-- Race
+		ability.arac = {
+			type = 'string',
+			value = 'human'
+		}
+	end
+
+	-- ## Text
+	do
+		-- Editor Suffix
+		ability.ansf = {
+			type = 'string',
+			value = '(Star Ruby)'
+		}
+
+		-- Name
+		ability.anam = {
+			type = 'string',
+			value = 'Abilities'
+		}
+
+		-- Tooltip - Normal
+		ability.atp1 = {
+			type = 'string',
+			values = {
+				[1] = '|cff33ff33Star Ruby Abilities|r'
+			}
+		}
+
+		-- Tooltip - Normal - Extended
+		ability.aub1 = {
+			type = 'string',
+			values = {}
+		}
+
+		local text = 'Enemies within <%s,Area1> range will receive'
+			.. ' <%s,Cool%d> spell damage per second.'
+
+		for level = 1, 11 do
+			ability.aub1.values [level] = string.format (
+				text, ids.immolation, ids.immolation, level)
+		end
+	end
+end

--- a/share/objects/specials/star-ruby/02-blood-star.lua
+++ b/share/objects/specials/star-ruby/02-blood-star.lua
@@ -1,8 +1,118 @@
 local map = ...
 local objects = map.objects
-local globals = map.globals
 
-local id = require ('lib.gem.id')
+local ids = {
+	immolation = 'A015'
+}
 
--- # Blood Star
-local unit = objects [id (globals.Gem_Special__STAR_RUBY_2)]
+-- # Blood Star Immolation
+do
+	local ability = {
+		type = 'ability',
+		base = 'ACev'
+	}
+	objects [ids.immolation] = ability
+
+	-- ## Art
+	do
+		-- Button Position - Normal (X)
+		ability.abpx = {
+			type = 'integer',
+			value = 3
+		}
+
+		-- Button Position - Normal (Y)
+		ability.abpy = {
+			type = 'integer',
+			value = 1
+		}
+
+		-- Icon - Normal
+		ability.aart = {
+			type = 'string',
+			value = 'ReplaceableTextures\\PassiveButtons\\PASBTNStatUp.blp'
+		}
+	end
+
+	-- ## Data
+	do
+		-- Chance to Evade
+		ability.Eev1 = {
+			data = 1,
+			type = 'unreal',
+			values = {
+				[1] = 0
+			}
+		}
+	end
+
+	-- ## Stats
+	do
+		-- Area of Effect
+		ability.aare = {
+			type = 'unreal',
+			values = {
+				[1] = 500
+			}
+		}
+
+		-- Cooldown
+		ability.acdn = {
+			type = 'unreal',
+			values = {}
+		}
+
+		for level = 1, 11 do
+			ability.acdn.values [level] = 50 * (1 + 0.1 * (level - 1))
+		end
+
+		-- Levels
+		ability.alev = {
+			type = 'integer',
+			value = 11
+		}
+
+		-- Race
+		ability.arac = {
+			type = 'string',
+			value = 'human'
+		}
+	end
+
+	-- ## Text
+	do
+		-- Editor Suffix
+		ability.ansf = {
+			type = 'string',
+			value = '(Blood Star)'
+		}
+
+		-- Name
+		ability.anam = {
+			type = 'string',
+			value = 'Abilities'
+		}
+
+		-- Tooltip - Normal
+		ability.atp1 = {
+			type = 'string',
+			values = {
+				[1] = '|cff33ff33Blood Star Abilities|r'
+			}
+		}
+
+		-- Tooltip - Normal - Extended
+		ability.aub1 = {
+			type = 'string',
+			values = {}
+		}
+
+		local text = 'Enemies within <%s,Area1> range will receive'
+			.. ' <%s,Cool%d> spell damage per second.'
+
+		for level = 1, 11 do
+			ability.aub1.values [level] = string.format (
+				text, ids.immolation, ids.immolation, level)
+		end
+	end
+end

--- a/share/objects/specials/uranium/immolation.lua
+++ b/share/objects/specials/uranium/immolation.lua
@@ -1,0 +1,118 @@
+local map = ...
+local objects = map.objects
+
+local ids = {
+	immolation = 'A00K'
+}
+
+-- # Uranium Immolation
+do
+	local ability = {
+		type = 'ability',
+		base = 'ACev'
+	}
+	objects [ids.immolation] = ability
+
+	-- ## Art
+	do
+		-- Button Position - Normal (X)
+		ability.abpx = {
+			type = 'integer',
+			value = 3
+		}
+
+		-- Button Position - Normal (Y)
+		ability.abpy = {
+			type = 'integer',
+			value = 1
+		}
+
+		-- Icon - Normal
+		ability.aart = {
+			type = 'string',
+			value = 'ReplaceableTextures\\PassiveButtons\\PASBTNStatUp.blp'
+		}
+	end
+
+	-- ## Data
+	do
+		-- Chance to Evade
+		ability.Eev1 = {
+			data = 1,
+			type = 'unreal',
+			values = {
+				[1] = 0
+			}
+		}
+	end
+
+	-- ## Stats
+	do
+		-- Area of Effect
+		ability.aare = {
+			type = 'unreal',
+			values = {
+				[1] = 500
+			}
+		}
+
+		-- Cooldown
+		ability.acdn = {
+			type = 'unreal',
+			values = {}
+		}
+
+		for level = 1, 11 do
+			ability.acdn.values [level] = 200 * (1 + 0.1 * (level - 1))
+		end
+
+		-- Levels
+		ability.alev = {
+			type = 'integer',
+			value = 11
+		}
+
+		-- Race
+		ability.arac = {
+			type = 'string',
+			value = 'human'
+		}
+	end
+
+	-- ## Text
+	do
+		-- Editor Suffix
+		ability.ansf = {
+			type = 'string',
+			value = '(Uranium)'
+		}
+
+		-- Name
+		ability.anam = {
+			type = 'string',
+			value = 'Abilities II'
+		}
+
+		-- Tooltip - Normal
+		ability.atp1 = {
+			type = 'string',
+			values = {
+				[1] = '|cff33ff33Uranium Abilities 2|r'
+			}
+		}
+
+		-- Tooltip - Normal - Extended
+		ability.aub1 = {
+			type = 'string',
+			values = {}
+		}
+
+		local text = 'Enemies within <%s,Area1> range will receive'
+			.. ' <%s,Cool%d> spell damage per second.'
+
+		for level = 1, 11 do
+			ability.aub1.values [level] = string.format (
+				text, ids.immolation, ids.immolation, level)
+		end
+	end
+end

--- a/share/objects/unused-objects.lua
+++ b/share/objects/unused-objects.lua
@@ -8,3 +8,10 @@ objects ['n006'] = nil
 -- Old difficulty aura buffs.
 objects ['B003'] = nil
 objects ['B009'] = nil
+
+-- Buffs from old Immolation.
+objects ['B00E'] = nil
+objects ['B00C'] = nil
+objects ['B00S'] = nil
+objects ['B00D'] = nil
+objects ['B00U'] = nil

--- a/src/effect.j
+++ b/src/effect.j
@@ -1,0 +1,30 @@
+globals
+	effect array Effect___SFX
+endglobals
+
+function Effect___Expires takes nothing returns boolean
+	local integer runner = Run__Scheduled ()
+
+	call DestroyEffect (Effect___SFX [runner])
+	set Effect___SFX [runner] = null
+
+	return true
+endfunction
+
+function Effect__Set_Lifespan takes effect sfx, real duration returns nothing
+	local integer runner
+
+	if sfx == null then
+		return
+	endif
+
+	if duration < 0.0 then
+		set duration = 0.0
+	endif
+
+	set runner = Run__After (duration, function Effect___Expires)
+
+	if runner != Run__NULL then
+		set Effect___SFX [runner] = sfx
+	endif
+endfunction

--- a/src/gem-3.1.j
+++ b/src/gem-3.1.j
@@ -1687,7 +1687,7 @@ function Trig_Ancient_Bloodstone_Actions takes nothing returns nothing
 	set victim = GetTriggerUnit ()
 	set units = CreateGroup ()
 
-	set name = UnitId2String (Gem_Special__BLOODSTONE_1)
+	set name = UnitId2String (Gem_Special__BLOOD_STONE_1)
 	call GroupEnumUnitsOfType (units, name, null)
 	loop
 		set which = FirstOfGroup (units)
@@ -1699,7 +1699,7 @@ function Trig_Ancient_Bloodstone_Actions takes nothing returns nothing
 		endif
 	endloop
 
-	set name = UnitId2String (Gem_Special__BLOODSTONE_2)
+	set name = UnitId2String (Gem_Special__BLOOD_STONE_2)
 	call GroupEnumUnitsOfType (units, name, null)
 	loop
 		set which = FirstOfGroup (units)

--- a/src/gem/changelog/unreleased.j
+++ b/src/gem/changelog/unreleased.j
@@ -14,6 +14,10 @@ function Gem_Changelog___Unreleased takes nothing returns nothing
 
 	set text = text + Color__Gold ("Fixed:") + "|n"
 	set text = text + "- Air pathing is now more consistent across all players.|n"
+	set text = text + "- Sources of AoE spell damage (i.e. Immolation) have been fixed:|n"
+	set text = text + "    - Multiple sources will now stack.|n"
+	set text = text + "    - Kill bonuses now apply to this type of damage, up to `100%` bonus.|n"
+	set text = text + "- Viper Slate's AoE spell damage was double what was intended.|n"
 	set text = text + "|n"
 
 	set text = text + Color__Gold ("Removed:") + "|n"

--- a/src/gem/combination.j
+++ b/src/gem/combination.j
@@ -217,7 +217,7 @@ function Gem_Combination___Recipe takes nothing returns boolean
 
 	call Unit_User_Data__Set (replacement, kills)
 
-	if combination == Gem_Special__STAR_RUBY_1 or combination == Gem_Special__STAR_RUBY_2 or combination == Gem_Special__BLOODSTONE_2 or combination == Gem_Slate__ELDER or combination == Gem_Slate__VIPER then
+	if combination == Gem_Special__STAR_RUBY_1 or combination == Gem_Special__STAR_RUBY_2 or combination == Gem_Special__BLOOD_STONE_2 or combination == Gem_Slate__ELDER or combination == Gem_Slate__VIPER then
 		set udg_CheckSpelllvlUNIT = replacement
 		call Trig_Find_spell_levels_Actions ()
 	endif

--- a/src/gem/immolation.j
+++ b/src/gem/immolation.j
@@ -1,0 +1,213 @@
+// # Gem Immolation
+//
+// A quick and dirty replacement for the Immolation ability.
+//
+// ## Notes
+// - There is a limitation of a single immolation source per unit.  There is
+//   no need, presently, to supersede this limitation.
+
+globals
+	integer array Gem_Immolation___Runner
+	string array Gem_Immolation___ID
+	unit array Gem_Immolation___Unit
+	real array Gem_Immolation___Damage
+	real array Gem_Immolation___Period
+	real array Gem_Immolation___Radius
+
+	integer Gem_Immolation___SFX = Node__NULL
+	constant integer Gem_Immolation___SFX_PATH = -1
+	constant integer Gem_Immolation___SFX_ATTACH = -2
+	constant integer Gem_Immolation___SFX_PERIOD = -3
+	constant integer Gem_Immolation___SFX_DURATION = -4
+
+	group Gem_Immolation___Group = null
+endglobals
+
+function Gem_Immolation___Damage takes nothing returns boolean
+	local integer runner = Run__Scheduled ()
+	local unit source = Gem_Immolation___Unit [runner]
+	local real x
+	local real y
+
+	local string id
+	local integer hash
+
+	local group targets
+	local real radius
+	local unit target
+	local integer index
+
+	local integer kills
+	local real bonus
+	local real damage
+	local real period
+
+	local integer list
+	local string path
+	local string attach
+	local real duration
+
+	local effect sfx
+	local real now
+
+	set Label = "Gem_Immolation___Damage"
+
+	if source == null then
+		return true
+	endif
+
+	set x = GetUnitX (source)
+	set y = GetUnitY (source)
+
+	set targets = Gem_Immolation___Group
+
+	if targets == null then
+		set targets = CreateGroup ()
+		set Gem_Immolation___Group = targets
+	endif
+
+	set id = Gem_Immolation___ID [runner]
+
+	if id == null then
+		set path = null
+		set attach = null
+		set duration = 0.0
+	else
+		set hash = StringHash (id)
+		set list = Node__Get_Integer (Gem_Immolation___SFX, hash)
+
+		set path = Node__Get_String (list, Gem_Immolation___SFX_PATH)
+		set attach = Node__Get_String (list, Gem_Immolation___SFX_ATTACH)
+		set period = Node__Get_Real (list, Gem_Immolation___SFX_PERIOD)
+		set duration = Node__Get_Real (list, Gem_Immolation___SFX_DURATION)
+	endif
+
+	set radius = Gem_Immolation___Radius [runner]
+	call GroupEnumUnitsInRange (targets, x, y, radius, null)
+
+	set kills = IMinBJ (100, Unit_User_Data__Get (source))
+	set bonus = 1.0 + 0.1 * I2R (kills / 10)
+	set damage = Gem_Immolation___Damage [runner] * bonus
+
+	set now = Time__To_Seconds (Time__Now ())
+
+	loop
+		set target = FirstOfGroup (targets)
+		exitwhen target == null
+		call GroupRemoveUnit (targets, target)
+
+		if GetOwningPlayer (target) == Gem__PLAYER_CREEPS and UnitAlive (target) then
+			if damage > 0 then
+				call UnitDamageTarget (source, target, damage, false, false, ATTACK_TYPE_NORMAL, DAMAGE_TYPE_UNIVERSAL, null)
+			endif
+
+			if path != null then
+				set index = Unit_Indexer__Unit_Index (target)
+
+				if Node__Get_Real (list, index) <= now then
+					call Node__Set_Real (list, index, now + period)
+					set sfx = AddSpecialEffectTarget (path, target, attach)
+
+					if duration == 0.0 then
+						call DestroyEffect (sfx)
+					else
+						call Effect__Set_Lifespan (sfx, duration)
+					endif
+				endif
+			endif
+		endif
+	endloop
+
+	return true
+endfunction
+
+function Gem_Immolation__Register takes unit which, string id, real radius, real period, real damage returns nothing
+	local integer index
+	local integer runner
+
+	if which == null or id == null then
+		return
+	endif
+
+	if radius <= 0.0 or period <= 0.0 or damage < 0.0 then
+		return
+	endif
+
+	set index = Unit_Indexer__Unit_Index (which)
+
+	if index == 0 then
+		return
+	endif
+
+	call Gem_Immolation__Deregister (which)
+	set runner = Run__Every (period, function Gem_Immolation___Damage)
+
+	if runner == Run__NULL then
+		return
+	endif
+
+	set Gem_Immolation___Runner [index] = runner
+	set Gem_Immolation___ID [runner] = id
+	set Gem_Immolation___Unit [runner] = which
+	set Gem_Immolation___Radius [runner] = radius
+	set Gem_Immolation___Damage [runner] = damage
+endfunction
+
+function Gem_Immolation__Deregister takes unit which returns nothing
+	local integer index
+	local integer runner
+
+	if which == null then
+		return
+	endif
+
+	set index = Unit_Indexer__Unit_Index (which)
+	set runner = Gem_Immolation___Runner [index]
+
+	if runner == Run__NULL then
+		return
+	endif
+
+	set Gem_Immolation___Runner [index] = Run__NULL
+	set Gem_Immolation___ID [runner] = null
+	set Gem_Immolation___Unit [runner] = null
+	set Gem_Immolation___Radius [runner] = 0.0
+	set Gem_Immolation___Damage [runner] = 0.0
+
+	call Run__Cancel (runner)
+endfunction
+
+function Gem_Immolation__Register_SFX takes string id, string sfx, string attach, real period, real duration returns nothing
+	local integer hash
+	local integer list
+
+	if id == null or sfx == null or attach == null then
+		return
+	endif
+
+	if period <= 0.0 or duration < 0.0 then
+		return
+	endif
+
+	if Gem_Immolation___SFX == Node__NULL then
+		set Gem_Immolation___SFX = Node__New ()
+	endif
+
+	set hash = StringHash (id)
+
+	if Node__Has_Integer (Gem_Immolation___SFX, hash) then
+		set list = Node__Get_Integer (Gem_Immolation___SFX, hash)
+	else
+		set list = Node__New ()
+		call Node__Set_Integer (Gem_Immolation___SFX, hash, list)
+	endif
+
+	call Node__Set_String (list, Gem_Immolation___SFX_PATH, sfx)
+	call Node__Set_String (list, Gem_Immolation___SFX_ATTACH, attach)
+	call Node__Set_Real (list, Gem_Immolation___SFX_PERIOD, period)
+	call Node__Set_Real (list, Gem_Immolation___SFX_DURATION, duration)
+endfunction
+
+function Gem_Immolation__Register_SFX takes string id, string sfx, string attach, real period returns nothing
+	call Gem_Immolation__Register_SFX (id, sfx, attach, period, 0.0)
+endfunction

--- a/src/gem/slate/initialize.j
+++ b/src/gem/slate/initialize.j
@@ -15,6 +15,7 @@ function Gem_Slate__Initialize takes nothing returns boolean
 	call Gem_Slate_Spell__Initialize ()
 	call Gem_Slate_Poison__Initialize ()
 	call Gem_Slate_Elder__Initialize ()
+	call Gem_Slate_Viper__Initialize ()
 
 	// Ancient:
 	set id = Gem_Slate___ID (Gem_Slate__ANCIENT)

--- a/src/gem/slate/viper.j
+++ b/src/gem/slate/viper.j
@@ -1,0 +1,54 @@
+function Gem_Slate_Viper___Register_SFX takes nothing returns nothing
+	local string id = "viper"
+	local string sfx = "Abilities\\Spells\\Undead\\ReplenishMana\\ReplenishManaCaster.mdl"
+	local string attach = "head"
+	local real period = 0.20
+	local real duration = 1.035
+
+	call Gem_Immolation__Register_SFX (id, sfx, attach, period, duration)
+endfunction
+
+function Gem_Slate_Viper___Register takes unit which returns nothing
+	local string id = "viper"
+	local real radius = 400.0
+	local real period = 0.20
+	local real damage = 10.0
+
+	call Gem_Immolation__Register (which, id, radius, period, damage)
+endfunction
+
+function Gem_Slate_Viper___Enter takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Slate__VIPER then
+		call Gem_Slate_Viper___Register (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Slate_Viper___Leave takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Slate__VIPER then
+		call Gem_Immolation__Deregister (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Slate_Viper__Initialize takes nothing returns nothing
+	local boolexpr enter
+	local boolexpr leave
+
+	call Gem_Slate_Viper___Register_SFX ()
+
+	set enter = Condition (function Gem_Slate_Viper___Enter)
+	call Unit_Event__On_Enter (enter)
+
+	set leave = Condition (function Gem_Slate_Viper___Leave)
+	call Unit_Event__On_Death (leave)
+	call Unit_Event__On_Leave (leave)
+endfunction

--- a/src/gem/special.j
+++ b/src/gem/special.j
@@ -40,8 +40,8 @@ globals
 	constant integer Gem_Special__BLACK_OPAL_1 = 'h015'
 	constant integer Gem_Special__BLACK_OPAL_2 = 'h02K'
 
-	constant integer Gem_Special__BLOODSTONE_1 = 'h01O'
-	constant integer Gem_Special__BLOODSTONE_2 = 'h02U'
+	constant integer Gem_Special__BLOOD_STONE_1 = 'h01O'
+	constant integer Gem_Special__BLOOD_STONE_2 = 'h02U'
 
 	constant integer Gem_Special__YELLOW_SAPPHIRE_1 = 'h014'
 	constant integer Gem_Special__YELLOW_SAPPHIRE_2 = 'h02R'

--- a/src/gem/special/blood-stone.j
+++ b/src/gem/special/blood-stone.j
@@ -1,0 +1,3 @@
+function Gem_Special_Blood_Stone__Initialize takes nothing returns nothing
+	call Preload__Ability ('A07A') // Forked Lightning
+endfunction

--- a/src/gem/special/blood-stone.j
+++ b/src/gem/special/blood-stone.j
@@ -1,3 +1,55 @@
+function Gem_Special_Blood_Stone___Register_SFX takes nothing returns nothing
+	local string id = "blood stone"
+	local string sfx = "Abilities\\Spells\\Human\\FlameStrike\\FlameStrikeDamageTarget.mdl"
+	local string attach = "chest"
+	local real duration = 2.1
+	local real period = 2.1
+
+	call Gem_Immolation__Register_SFX (id, sfx, attach, period, duration)
+endfunction
+
+function Gem_Special_Blood_Stone___Register takes unit which returns nothing
+	local string id = "blood stone"
+	local real radius = 500.0
+	local real period = 0.20
+	local real damage = 15.0
+
+	call Gem_Immolation__Register (which, id, radius, period, damage)
+endfunction
+
+function Gem_Special_Blood_Stone___Enter takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__BLOOD_STONE_1 then
+		call Gem_Special_Blood_Stone___Register (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Special_Blood_Stone___Leave takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__BLOOD_STONE_1 then
+		call Gem_Immolation__Deregister (which)
+	endif
+
+	return true
+endfunction
+
 function Gem_Special_Blood_Stone__Initialize takes nothing returns nothing
+	local boolexpr enter
+	local boolexpr leave
+
+	call Gem_Special_Blood_Stone___Register_SFX ()
 	call Preload__Ability ('A07A') // Forked Lightning
+
+	set enter = Condition (function Gem_Special_Blood_Stone___Enter)
+	call Unit_Event__On_Enter (enter)
+
+	set leave = Condition (function Gem_Special_Blood_Stone___Leave)
+	call Unit_Event__On_Death (leave)
+	call Unit_Event__On_Leave (leave)
 endfunction

--- a/src/gem/special/bloodstone.j
+++ b/src/gem/special/bloodstone.j
@@ -1,3 +1,0 @@
-function Gem_Special_Bloodstone__Initialize takes nothing returns nothing
-	call Preload__Ability ('A07A') // Forked Lightning
-endfunction

--- a/src/gem/special/initialize.j
+++ b/src/gem/special/initialize.j
@@ -8,6 +8,7 @@ function Gem_Special__Initialize takes nothing returns boolean
 	// Preload abilities:
 	call Gem_Special_Blood_Stone__Initialize ()
 	call Gem_Special_Tourmaline__Initialize ()
+	call Gem_Special_Red_Crystal__Initialize ()
 
 	// Malachite:
 	call Gem_Recipe__Register (Gem_Special__MALACHITE_1, Gem_Gems__AQUAMARINE_CHIPPED, Gem_Gems__EMERALD_CHIPPED, Gem_Gems__OPAL_CHIPPED, 0)

--- a/src/gem/special/initialize.j
+++ b/src/gem/special/initialize.j
@@ -9,6 +9,7 @@ function Gem_Special__Initialize takes nothing returns boolean
 	call Gem_Special_Blood_Stone__Initialize ()
 	call Gem_Special_Tourmaline__Initialize ()
 	call Gem_Special_Red_Crystal__Initialize ()
+	call Gem_Special_Star_Ruby__Initialize ()
 
 	// Malachite:
 	call Gem_Recipe__Register (Gem_Special__MALACHITE_1, Gem_Gems__AQUAMARINE_CHIPPED, Gem_Gems__EMERALD_CHIPPED, Gem_Gems__OPAL_CHIPPED, 0)

--- a/src/gem/special/initialize.j
+++ b/src/gem/special/initialize.j
@@ -6,7 +6,7 @@ function Gem_Special__Initialize takes nothing returns boolean
 	call Gem_Special___Initialize_Jade ()
 
 	// Preload abilities:
-	call Gem_Special_Bloodstone__Initialize ()
+	call Gem_Special_Blood_Stone__Initialize ()
 	call Gem_Special_Tourmaline__Initialize ()
 
 	// Malachite:
@@ -43,7 +43,7 @@ function Gem_Special__Initialize takes nothing returns boolean
 	call Gem_Recipe__Register (Gem_Special__BLACK_OPAL_1, Gem_Gems__OPAL_PERFECT, Gem_Gems__DIAMOND_FLAWLESS, Gem_Gems__AQUAMARINE_NORMAL, 0)
 
 	// Blood Stone:
-	call Gem_Recipe__Register (Gem_Special__BLOODSTONE_1, Gem_Gems__RUBY_PERFECT, Gem_Gems__AQUAMARINE_FLAWLESS, Gem_Gems__AMETHYST_NORMAL, 0)
+	call Gem_Recipe__Register (Gem_Special__BLOOD_STONE_1, Gem_Gems__RUBY_PERFECT, Gem_Gems__AQUAMARINE_FLAWLESS, Gem_Gems__AMETHYST_NORMAL, 0)
 
 	// Yellow Sapphire:
 	call Gem_Recipe__Register (Gem_Special__YELLOW_SAPPHIRE_1, Gem_Gems__SAPPHIRE_PERFECT, Gem_Gems__RUBY_FLAWLESS, Gem_Gems__TOPAZ_FLAWLESS, 0)

--- a/src/gem/special/initialize.j
+++ b/src/gem/special/initialize.j
@@ -10,6 +10,7 @@ function Gem_Special__Initialize takes nothing returns boolean
 	call Gem_Special_Tourmaline__Initialize ()
 	call Gem_Special_Red_Crystal__Initialize ()
 	call Gem_Special_Star_Ruby__Initialize ()
+	call Gem_Special_Uranium__Initialize ()
 
 	// Malachite:
 	call Gem_Recipe__Register (Gem_Special__MALACHITE_1, Gem_Gems__AQUAMARINE_CHIPPED, Gem_Gems__EMERALD_CHIPPED, Gem_Gems__OPAL_CHIPPED, 0)

--- a/src/gem/special/red-crystal.j
+++ b/src/gem/special/red-crystal.j
@@ -1,0 +1,69 @@
+function Gem_Special_Red_Crystal___Register_SFX takes nothing returns nothing
+	local string id = "red crystal"
+	local string sfx = "Abilities\\Spells\\Demon\\DemonBoltImpact\\DemonBoltImpact.mdl"
+	local string attach = "chest"
+	local real period = 0.20
+
+	call Gem_Immolation__Register_SFX (id, sfx, attach, period)
+endfunction
+
+function Gem_Special_Red_Crystal___Register takes unit which returns nothing
+	local string id = "red crystal"
+	local real radius = 1500.0
+	local real period = 0.20
+	local real damage = 10.0
+
+	call Gem_Immolation__Register (which, id, radius, period, damage)
+endfunction
+
+function Gem_Special_Red_Crystal___Enter takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__RED_CRYSTAL_3 then
+		call Gem_Special_Red_Crystal___Register (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Special_Red_Crystal___Leave takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__RED_CRYSTAL_3 then
+		call Gem_Immolation__Deregister (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Special_Red_Crystal___Upgrade takes nothing returns boolean
+	local unit which = GetTriggerUnit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__RED_CRYSTAL_3 then
+		call Gem_Special_Red_Crystal___Register (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Special_Red_Crystal__Initialize takes nothing returns nothing
+	local boolexpr enter
+	local boolexpr leave
+	local trigger upgrade
+
+	call Gem_Special_Red_Crystal___Register_SFX ()
+
+	set enter = Condition (function Gem_Special_Red_Crystal___Enter)
+	call Unit_Event__On_Enter (enter)
+
+	set leave = Condition (function Gem_Special_Red_Crystal___Leave)
+	call Unit_Event__On_Death (leave)
+	call Unit_Event__On_Leave (leave)
+
+	set upgrade = Trigger__New ()
+	call Trigger__Try (upgrade, function Gem_Special_Red_Crystal___Upgrade)
+	call TriggerRegisterAnyUnitEventBJ (upgrade, EVENT_PLAYER_UNIT_UPGRADE_FINISH)
+endfunction

--- a/src/gem/special/star-ruby.j
+++ b/src/gem/special/star-ruby.j
@@ -1,0 +1,85 @@
+function Gem_Special_Star_Ruby___Register_SFX takes nothing returns nothing
+	local string id = "star ruby"
+	local string sfx = "Abilities\\Spells\\Items\\AIfb\\AIfbSpecialArt.mdl"
+	local string attach = "head"
+	local real period = 0.290
+
+	call Gem_Immolation__Register_SFX (id, sfx, attach, period)
+endfunction
+
+function Gem_Special_Star_Ruby___Register takes unit which returns nothing
+	local string id = "star ruby"
+	local real radius
+	local real period = 0.25
+	local real damage
+
+	if GetUnitTypeId (which) == Gem_Special__STAR_RUBY_1 then
+		set damage = 10.0
+		set radius = 265.0
+	elseif GetUnitTypeId (which) == Gem_Special__STAR_RUBY_2 then
+		set damage = 12.5
+		set radius = 500.0
+	else
+		return
+	endif
+
+	call Gem_Immolation__Register (which, id, radius, period, damage)
+endfunction
+
+function Gem_Special_Star_Ruby___Enter takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__STAR_RUBY_1 then
+		call Gem_Special_Star_Ruby___Register (which)
+	elseif id == Gem_Special__STAR_RUBY_2 then
+		call Gem_Special_Star_Ruby___Register (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Special_Star_Ruby___Leave takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__STAR_RUBY_1 then
+		call Gem_Immolation__Deregister (which)
+	elseif id == Gem_Special__STAR_RUBY_2 then
+		call Gem_Immolation__Deregister (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Special_Star_Ruby___Upgrade takes nothing returns boolean
+	local unit which = GetTriggerUnit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__STAR_RUBY_2 then
+		call Gem_Special_Star_Ruby___Register (which)
+	elseif id == Gem_Special__STAR_RUBY_3 then
+		call Gem_Immolation__Deregister (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Special_Star_Ruby__Initialize takes nothing returns nothing
+	local boolexpr enter
+	local boolexpr leave
+	local trigger upgrade
+
+	call Gem_Special_Star_Ruby___Register_SFX ()
+
+	set enter = Condition (function Gem_Special_Star_Ruby___Enter)
+	call Unit_Event__On_Enter (enter)
+
+	set leave = Condition (function Gem_Special_Star_Ruby___Leave)
+	call Unit_Event__On_Death (leave)
+	call Unit_Event__On_Leave (leave)
+
+	set upgrade = Trigger__New ()
+	call Trigger__Try (upgrade, function Gem_Special_Star_Ruby___Upgrade)
+	call TriggerRegisterAnyUnitEventBJ (upgrade, EVENT_PLAYER_UNIT_UPGRADE_FINISH)
+endfunction

--- a/src/gem/special/uranium.j
+++ b/src/gem/special/uranium.j
@@ -1,0 +1,57 @@
+function Gem_Special_Uranium___Register_SFX takes nothing returns nothing
+	local string id = "uranium"
+	local string sfx = "Abilities\\Weapons\\Bolt\\BoltImpact.mdl"
+	local string attach = "head"
+	local real period = 1.0
+
+	call Gem_Immolation__Register_SFX (id, sfx, attach, period)
+endfunction
+
+function Gem_Special_Uranium___Register takes unit which returns nothing
+	local string id = "uranium"
+	local real radius = 500.0
+	local real period = 0.10
+	local real damage = 20.0
+
+	call Gem_Immolation__Register (which, id, radius, period, damage)
+endfunction
+
+function Gem_Special_Uranium___Enter takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__URANIUM_1 then
+		call Gem_Special_Uranium___Register (which)
+	elseif id == Gem_Special__URANIUM_2 then
+		call Gem_Special_Uranium___Register (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Special_Uranium___Leave takes nothing returns boolean
+	local unit which = Unit_Event__The_Unit ()
+	local integer id = GetUnitTypeId (which)
+
+	if id == Gem_Special__URANIUM_1 then
+		call Gem_Immolation__Deregister (which)
+	elseif id == Gem_Special__URANIUM_2 then
+		call Gem_Immolation__Deregister (which)
+	endif
+
+	return true
+endfunction
+
+function Gem_Special_Uranium__Initialize takes nothing returns nothing
+	local boolexpr enter
+	local boolexpr leave
+
+	call Gem_Special_Uranium___Register_SFX ()
+
+	set enter = Condition (function Gem_Special_Uranium___Enter)
+	call Unit_Event__On_Enter (enter)
+
+	set leave = Condition (function Gem_Special_Uranium___Leave)
+	call Unit_Event__On_Death (leave)
+	call Unit_Event__On_Leave (leave)
+endfunction


### PR DESCRIPTION
# Immolation Rework
Attempt at implementing #55.

## Testing Version
- [Gem TD Plus 1.6-im-11_g28870b4.w3x.zip](https://github.com/nvs/gem/files/3144754/Gem.TD.Plus.1.6-im-11_g28870b4.w3x.zip)

## To-Do
- [x] Improve performance. The sheer number of effects is a drain. Probably decouple the damage from the effect, having a unit be marked by a single type class of immolation at a time.
- [x] Double check performance of the damage without any effects at all. Kind of a stress test for the scheduler.
- [x] Handle effect lifespan.
- [x] Generic Immolation replacement.
- [x] Viper Slate.
- [x] Star Ruby.
- [x] Blood Star.
- [x] Rose Quartz Crystal.
- [x] Uranium 235.
- [x] Uranium 238.
- [x] Blood Stone
- [x] Handle upgrades. Currently, a unit is registered to the Immolation system for unit leaves/enters events. However, this does not fire when a unit upgrades.
- [x] Shift buttons to utilize Evasion, as they will merely become display only.
- [x] Update Changelog:
    - In particular, mention that Viper Slate's stated damage was incorrect. Due to being misconfigured, it was doing twice the stated damage. That has been fixed.
    - Multiple sources of Immolation damage will now stack, which has never happened before.
    - Kill bonuses will now apply to Immolation damage, which has never happened before (even if it said it did).

## Notes
- Due to the buggy nature of true Immolation, there were very few effects ever created. The naive initial design of this system creates an effect on every damage application. So, multiple effects per unit per second (which mimics Immolation), that are either destroyed immediately or last up to a couple seconds. Not only is performance bad due to the sheer number of effects. But the eye candy on the creeps is horrific. Definitely need to filter things a bit.