### PR TITLE
fix: restore incorrect unit portraits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ For a full list of changes to the project, please consult the commit log.
 
 ## [Unreleased]
 
-- N/A
+### Fixed
+
+- Restore incorrect unit protraits to their previous (less bad) versions.
 
 ## [1.6.14] - 2023-05-24
 

--- a/etc/gem.lua
+++ b/etc/gem.lua
@@ -22,6 +22,7 @@ return {
 		'share/objects',
 		'share/hide-buttons.lua',
 		'share/tooltips.lua',
+		'share/fix/unit-portraits.lua',
 
 		'share/imports/import-directory.lua',
 	},

--- a/share/fix/unit-portraits.lua
+++ b/share/fix/unit-portraits.lua
@@ -1,0 +1,20 @@
+local map = ...
+local objects = map.objects
+
+for _, object in pairs(objects) do
+	if object.type == 'unit' then
+		local portrait = object.upor
+
+		if not portrait then
+			portrait = {
+				type = 'string',
+			}
+
+			object.upor = portrait
+		end
+
+		if not portrait.value then
+			portrait.value = ''
+		end
+	end
+end


### PR DESCRIPTION
Apparently, the `upor` field to unit objects was introduced at some
point. If this is `None`, then it will use the value of `umdl`. Setting
it to the empty string (i.e. `''`) achieves this.

Closes: nvs/gem#586
